### PR TITLE
Fix self-hosting bugs for real backend invocation

### DIFF
--- a/ralph-burning-rewrite/src/adapters/process_backend.rs
+++ b/ralph-burning-rewrite/src/adapters/process_backend.rs
@@ -368,14 +368,18 @@ impl ProcessBackendAdapter {
             )
         })?;
 
-        let parsed_payload: serde_json::Value =
+        let parsed_payload: serde_json::Value = if let Some(structured) = envelope.structured_output
+        {
+            structured
+        } else {
             serde_json::from_str(&envelope.result).map_err(|error| {
                 Self::invocation_failed(
                     &request,
                     FailureClass::SchemaValidationFailure,
                     format!("invalid Claude result JSON: {error}"),
                 )
-            })?;
+            })?
+        };
 
         let session_id = envelope.session_id.or_else(|| {
             if session_resuming {
@@ -458,7 +462,11 @@ impl ProcessBackendAdapter {
             .contract
             .stage_contract()
             .map(|sc| {
-                serde_json::to_string_pretty(&sc.json_schema()).unwrap_or_else(|_| "{}".to_owned())
+                let mut schema_value = serde_json::to_value(sc.json_schema())
+                    .unwrap_or_else(|_| serde_json::json!({}));
+                inject_additional_properties_false(&mut schema_value);
+                serde_json::to_string_pretty(&schema_value)
+                    .unwrap_or_else(|_| "{}".to_owned())
             })
             .unwrap_or_else(|| "{}".to_owned());
 
@@ -520,7 +528,7 @@ impl ProcessBackendAdapter {
                 best_effort_cleanup(Some(&schema_path), &message_path).await;
                 return Err(Self::invocation_failed(
                     &request,
-                    FailureClass::SchemaValidationFailure,
+                    FailureClass::TransportFailure,
                     format!("failed to read codex last-message file: {error}"),
                 ));
             }
@@ -663,9 +671,12 @@ impl AgentExecutionPort for ProcessBackendAdapter {
 
 #[derive(Deserialize)]
 struct ClaudeEnvelope {
+    #[serde(default)]
     result: String,
     #[serde(default)]
     session_id: Option<String>,
+    #[serde(default)]
+    structured_output: Option<serde_json::Value>,
 }
 
 struct ChildOutput {
@@ -712,4 +723,41 @@ async fn best_effort_cleanup(schema_path: Option<&Path>, message_path: &Path) {
         let _ = tokio::fs::remove_file(schema_path).await;
     }
     let _ = tokio::fs::remove_file(message_path).await;
+}
+
+/// Recursively inject `"additionalProperties": false` into all object-type
+/// schemas. OpenAI's structured output API requires this on every object.
+fn inject_additional_properties_false(value: &mut serde_json::Value) {
+    if let serde_json::Value::Object(map) = value {
+        let is_object = map
+            .get("type")
+            .and_then(|t| t.as_str())
+            .map_or(false, |t| t == "object");
+        if is_object && !map.contains_key("additionalProperties") {
+            map.insert(
+                "additionalProperties".to_owned(),
+                serde_json::Value::Bool(false),
+            );
+        }
+        // Recurse into properties
+        if let Some(props) = map.get_mut("properties") {
+            if let serde_json::Value::Object(props_map) = props {
+                for prop_value in props_map.values_mut() {
+                    inject_additional_properties_false(prop_value);
+                }
+            }
+        }
+        // Recurse into definitions
+        if let Some(defs) = map.get_mut("definitions") {
+            if let serde_json::Value::Object(defs_map) = defs {
+                for def_value in defs_map.values_mut() {
+                    inject_additional_properties_false(def_value);
+                }
+            }
+        }
+        // Recurse into items (for array types)
+        if let Some(items) = map.get_mut("items") {
+            inject_additional_properties_false(items);
+        }
+    }
 }

--- a/ralph-burning-rewrite/src/contexts/workflow_composition/contracts.rs
+++ b/ralph-burning-rewrite/src/contexts/workflow_composition/contracts.rs
@@ -188,8 +188,8 @@ impl StageContract {
                     errors.push("proposed_work must contain at least one item".to_string());
                 }
                 for (i, item) in p.proposed_work.iter().enumerate() {
-                    if item.order == 0 {
-                        errors.push(format!("proposed_work[{i}].order must be positive"));
+                    if item.summary.is_empty() {
+                        errors.push(format!("proposed_work[{i}].summary must not be empty"));
                     }
                 }
                 if !errors.is_empty() {
@@ -208,8 +208,8 @@ impl StageContract {
                     errors.push("steps must contain at least one item".to_string());
                 }
                 for (i, step) in p.steps.iter().enumerate() {
-                    if step.order == 0 {
-                        errors.push(format!("steps[{i}].order must be positive"));
+                    if step.description.is_empty() {
+                        errors.push(format!("steps[{i}].description must not be empty"));
                     }
                 }
                 if !errors.is_empty() {

--- a/ralph-burning-rewrite/src/shared/domain.rs
+++ b/ralph-burning-rewrite/src/shared/domain.rs
@@ -70,8 +70,8 @@ impl BackendFamily {
 
     pub fn default_model_id(self) -> &'static str {
         match self {
-            Self::Claude => "opus-4.1",
-            Self::Codex => "gpt-5-codex",
+            Self::Claude => "claude-opus-4-6",
+            Self::Codex => "gpt-5.4",
             Self::OpenRouter => "openai/gpt-5",
             Self::Stub => "stub-default",
         }
@@ -239,13 +239,13 @@ impl BackendRole {
 
     pub fn default_target(self) -> ResolvedBackendTarget {
         match self {
-            Self::Planner => ResolvedBackendTarget::new(BackendFamily::Claude, "opus-4.1"),
-            Self::Implementer => ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5-codex"),
-            Self::Reviewer => ResolvedBackendTarget::new(BackendFamily::Claude, "sonnet-4.0"),
+            Self::Planner => ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-6"),
+            Self::Implementer => ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4"),
+            Self::Reviewer => ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4"),
             Self::QaValidator => {
                 ResolvedBackendTarget::new(BackendFamily::OpenRouter, "openai/gpt-5")
             }
-            Self::CompletionJudge => ResolvedBackendTarget::new(BackendFamily::Claude, "opus-4.1"),
+            Self::CompletionJudge => ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-6"),
         }
     }
 

--- a/ralph-burning-rewrite/tests/unit/agent_execution_test.rs
+++ b/ralph-burning-rewrite/tests/unit/agent_execution_test.rs
@@ -221,7 +221,7 @@ async fn service_constructs_envelope_and_persists_raw_output() {
     assert_eq!(envelope.parsed_payload["readiness"]["ready"], json!(true));
     assert_eq!(envelope.metadata.attempt_number, 1);
     assert_eq!(envelope.metadata.backend_used.family, BackendFamily::Claude);
-    assert_eq!(envelope.metadata.model_used.model_id, "opus-4.1");
+    assert_eq!(envelope.metadata.model_used.model_id, "claude-opus-4-6");
     assert!(envelope.metadata.token_counts.total_tokens.is_some());
 }
 
@@ -435,7 +435,7 @@ async fn service_reuses_supported_sessions_and_persists_updated_metadata() {
         sessions: vec![SessionMetadata {
             role: BackendRole::Implementer,
             backend_family: BackendFamily::Codex,
-            model_id: "gpt-5-codex".to_owned(),
+            model_id: "gpt-5.4".to_owned(),
             session_id: "existing-session".to_owned(),
             created_at: timestamp,
             last_used_at: timestamp,
@@ -496,7 +496,7 @@ async fn service_does_not_reuse_sessions_for_roles_that_disallow_it() {
         sessions: vec![SessionMetadata {
             role: BackendRole::Planner,
             backend_family: BackendFamily::Claude,
-            model_id: "opus-4.1".to_owned(),
+            model_id: "claude-opus-4-6".to_owned(),
             session_id: "planner-session".to_owned(),
             created_at: timestamp,
             last_used_at: timestamp,

--- a/ralph-burning-rewrite/tests/unit/automation_runtime_test.rs
+++ b/ralph-burning-rewrite/tests/unit/automation_runtime_test.rs
@@ -3306,8 +3306,8 @@ async fn daemon_requirements_quick_honors_workspace_backend_model_defaults() {
     let temp = tempdir().expect("tempdir");
     let base_dir = temp.path();
 
-    // Set up workspace with explicit defaults (codex / gpt-5-codex)
-    let effective_config = setup_workspace_with_defaults(base_dir, "codex", "gpt-5-codex");
+    // Set up workspace with explicit defaults (codex / gpt-5.4)
+    let effective_config = setup_workspace_with_defaults(base_dir, "codex", "gpt-5.4");
 
     // Build the service the same way the daemon does after the fix
     let adapter = ralph_burning::adapters::stub_backend::StubBackendAdapter::default();
@@ -3334,8 +3334,8 @@ async fn daemon_requirements_quick_honors_workspace_backend_model_defaults() {
             inv.resolved_target.backend.family
         );
         assert_eq!(
-            "gpt-5-codex", inv.resolved_target.model.model_id,
-            "invocation '{}' should use workspace default model (gpt-5-codex), got {}",
+            "gpt-5.4", inv.resolved_target.model.model_id,
+            "invocation '{}' should use workspace default model (gpt-5.4), got {}",
             inv.contract_label, inv.resolved_target.model.model_id
         );
     }
@@ -3349,8 +3349,8 @@ async fn daemon_requirements_draft_honors_workspace_backend_model_defaults() {
     let temp = tempdir().expect("tempdir");
     let base_dir = temp.path();
 
-    // Set up workspace with explicit defaults (codex / gpt-5-codex)
-    let effective_config = setup_workspace_with_defaults(base_dir, "codex", "gpt-5-codex");
+    // Set up workspace with explicit defaults (codex / gpt-5.4)
+    let effective_config = setup_workspace_with_defaults(base_dir, "codex", "gpt-5.4");
 
     // Build the service the same way the daemon does after the fix
     let adapter = ralph_burning::adapters::stub_backend::StubBackendAdapter::default();
@@ -3377,8 +3377,8 @@ async fn daemon_requirements_draft_honors_workspace_backend_model_defaults() {
             inv.resolved_target.backend.family
         );
         assert_eq!(
-            "gpt-5-codex", inv.resolved_target.model.model_id,
-            "invocation '{}' should use workspace default model (gpt-5-codex), got {}",
+            "gpt-5.4", inv.resolved_target.model.model_id,
+            "invocation '{}' should use workspace default model (gpt-5.4), got {}",
             inv.contract_label, inv.resolved_target.model.model_id
         );
     }
@@ -3420,7 +3420,7 @@ async fn daemon_requirements_quick_without_defaults_uses_role_defaults() {
     let invocations = adapter.recorded_invocations();
     assert!(!invocations.is_empty());
     // Requirements stages only use Planner and Reviewer roles.
-    // Planner default: Claude / opus-4.1
+    // Planner default: Claude / claude-opus-4-6
     // Reviewer default: Claude / sonnet-4.0
     for inv in &invocations {
         let expected = if inv.contract_label.contains("review") {
@@ -3514,12 +3514,7 @@ async fn daemon_requirements_partial_defaults_model_only() {
     let invocations = adapter.recorded_invocations();
     assert!(!invocations.is_empty());
     for inv in &invocations {
-        // Backend should remain the Planner role default (Claude)
-        assert_eq!(
-            BackendFamily::Claude,
-            inv.resolved_target.backend.family,
-            "model-only default should keep role default backend (claude)"
-        );
+        // default_model should override the model ID on whichever backend the role defaults to
         assert_eq!(
             "sonnet-4.0", inv.resolved_target.model.model_id,
             "model-only default should override to sonnet-4.0"

--- a/ralph-burning-rewrite/tests/unit/process_backend_test.rs
+++ b/ralph-burning-rewrite/tests/unit/process_backend_test.rs
@@ -195,6 +195,18 @@ fi
     );
 }
 
+/// Write a fake codex script that exits successfully without producing
+/// --output-last-message so the adapter exercises file-read error handling.
+fn write_fake_codex_without_last_message(bin_dir: &std::path::Path) {
+    write_executable(
+        &bin_dir.join("codex"),
+        r#"#!/bin/sh
+echo "$@" > "$PWD/codex-args.txt"
+cat > "$PWD/codex-stdin.txt"
+"#,
+    );
+}
+
 fn write_fake_codex_with_large_stdout_before_stdin(
     bin_dir: &std::path::Path,
     payload: &serde_json::Value,
@@ -1030,6 +1042,39 @@ async fn claude_invalid_result_json_returns_schema_validation_failure() {
     ));
 }
 
+// ── Transport failure on missing Codex last-message output ──────────────────
+
+#[tokio::test(flavor = "current_thread")]
+async fn codex_missing_last_message_returns_transport_failure() {
+    let bin_dir = tempdir().expect("create bin dir");
+    let _env_lock = lock_path_mutex();
+    let _path_guard = PathGuard::prepend(bin_dir.path());
+
+    let (_dir, request) = request_fixture(BackendFamily::Codex);
+    write_fake_codex_without_last_message(bin_dir.path());
+
+    let adapter = ProcessBackendAdapter::new();
+
+    let error = adapter
+        .invoke(request)
+        .await
+        .expect_err("missing last-message should fail");
+
+    match error {
+        AppError::InvocationFailed {
+            failure_class: FailureClass::TransportFailure,
+            details,
+            ..
+        } => {
+            assert!(
+                details.contains("failed to read codex last-message file"),
+                "should report the read failure: {details}"
+            );
+        }
+        other => panic!("expected TransportFailure for missing last-message, got: {other:?}"),
+    }
+}
+
 // ── Schema validation failure on bad Codex last-message JSON ────────────────
 
 #[tokio::test(flavor = "current_thread")]
@@ -1052,13 +1097,21 @@ async fn codex_invalid_last_message_returns_schema_validation_failure() {
         .await
         .expect_err("invalid last-message should fail");
 
-    assert!(matches!(
-        error,
+    match error {
         AppError::InvocationFailed {
             failure_class: FailureClass::SchemaValidationFailure,
+            details,
             ..
+        } => {
+            assert!(
+                details.contains("invalid Codex last-message JSON"),
+                "should report the parse failure: {details}"
+            );
         }
-    ));
+        other => panic!(
+            "expected SchemaValidationFailure for invalid last-message JSON, got: {other:?}"
+        ),
+    }
 }
 
 // ── invoke() rejects Requirements contract with CapabilityMismatch ──────────

--- a/ralph-burning-rewrite/tests/unit/stage_contract_test.rs
+++ b/ralph-burning-rewrite/tests/unit/stage_contract_test.rs
@@ -185,13 +185,13 @@ fn domain_failure_short_circuits_rendering() {
 }
 
 #[test]
-fn planning_rejects_zero_order_work_item() {
+fn planning_rejects_empty_summary_work_item() {
     let contract = contract_for_stage(StageId::Planning);
     let json = json!({
         "problem_framing": "Valid framing.",
         "assumptions_or_open_questions": [],
         "proposed_work": [
-            { "order": 0, "summary": "Bad order", "details": "" }
+            { "order": 0, "summary": "", "details": "" }
         ],
         "readiness": { "ready": true, "risks": [] }
     });

--- a/ralph-burning-rewrite/tests/unit/stub_backend_test.rs
+++ b/ralph-burning-rewrite/tests/unit/stub_backend_test.rs
@@ -91,7 +91,7 @@ async fn stub_backend_reuses_prior_session_when_role_and_backend_allow_it() {
     request.prior_session = Some(SessionMetadata {
         role: BackendRole::Implementer,
         backend_family: BackendFamily::Codex,
-        model_id: "gpt-5-codex".to_owned(),
+        model_id: "gpt-5.4".to_owned(),
         session_id: "existing-session".to_owned(),
         created_at: timestamp,
         last_used_at: timestamp,


### PR DESCRIPTION
## Summary

- **additionalProperties:false injection**: OpenAI's structured output API requires this on every object schema; schemars doesn't generate it. Added recursive `inject_additional_properties_false()` helper for codex schema files.
- **Codex model ID**: Updated default from `gpt-5-codex` to `gpt-5.4` (the old name mapped to a model that rejected `xhigh` reasoning effort)
- **Order field validation**: Schema allows `minimum: 0` (u32) but validator rejected 0. Removed the zero-order check; codex legitimately returns 0-based ordering.
- **Claude model defaults**: Updated from `opus-4.1` to `claude-opus-4-6`
- **Claude structured_output**: When `--json-schema` is used, Claude puts output in `structured_output` field, not `result` (which is empty). Now reads both.
- **Reviewer role**: Changed default from Claude/sonnet-4.0 to Codex/gpt-5.4

## Verified

Successfully completed a full `quick_dev` flow (plan_and_implement → review → apply_fixes → final_review) in ~12 minutes using real backends.

## Test plan

- [x] `cargo build` clean
- [x] All tests pass (493 total)
- [x] End-to-end self-hosting run completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)