### PR TITLE
feat(lifecycle): make PID liveness safe across platforms and after PID reuse

### DIFF
--- a/src/adapters/fs.rs
+++ b/src/adapters/fs.rs
@@ -8,7 +8,9 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use chrono::{DateTime, Utc};
+#[cfg(all(unix, not(target_os = "linux")))]
+use chrono::NaiveDateTime;
+use chrono::{DateTime, TimeZone, Utc};
 use nix::fcntl::{Flock, FlockArg};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -193,6 +195,42 @@ struct RunBackendProcessSet {
 
 pub struct FileSystem;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessStartPrecision {
+    Precise,
+    #[cfg(any(test, all(unix, not(target_os = "linux"))))]
+    WholeSeconds,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProcessStartTime {
+    started_at: DateTime<Utc>,
+    precision: ProcessStartPrecision,
+}
+
+impl ProcessStartTime {
+    fn precise(started_at: DateTime<Utc>) -> Self {
+        Self {
+            started_at,
+            precision: ProcessStartPrecision::Precise,
+        }
+    }
+
+    #[cfg(any(test, all(unix, not(target_os = "linux"))))]
+    #[allow(dead_code)]
+    fn whole_seconds(started_at: DateTime<Utc>) -> Self {
+        Self {
+            started_at,
+            precision: ProcessStartPrecision::WholeSeconds,
+        }
+    }
+
+    fn matches_legacy_pid_record(self, record_started_at: DateTime<Utc>) -> bool {
+        let _ = self.precision;
+        self.started_at <= record_started_at
+    }
+}
+
 impl FileSystem {
     fn identity_is_authoritative(
         proc_start_ticks: Option<u64>,
@@ -204,10 +242,10 @@ impl FileSystem {
 
         #[cfg(all(unix, not(target_os = "linux")))]
         {
-            proc_start_marker.is_some_and(|marker| !marker.trim().is_empty())
+            return proc_start_marker.is_some();
         }
 
-        #[cfg(any(target_os = "linux", not(unix)))]
+        #[cfg(not(all(unix, not(target_os = "linux"))))]
         {
             let _ = proc_start_marker;
             false
@@ -229,17 +267,56 @@ impl FileSystem {
 
         #[cfg(all(unix, not(target_os = "linux")))]
         {
-            let Some(expected_marker) = proc_start_marker else {
-                return false;
-            };
-            return matches!(Self::proc_start_marker(pid), Some(actual_marker) if actual_marker == expected_marker);
+            return matches!(
+                (proc_start_marker, Self::proc_start_marker(pid)),
+                (Some(expected_marker), Some(actual_marker)) if actual_marker == expected_marker
+            );
         }
 
-        #[cfg(any(target_os = "linux", not(unix)))]
+        #[cfg(not(all(unix, not(target_os = "linux"))))]
         {
             let _ = proc_start_marker;
             false
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn process_started_at(pid: u32) -> Option<ProcessStartTime> {
+        let start_ticks = Self::proc_start_ticks(pid)?;
+        let ticks_per_second = Command::new("getconf")
+            .arg("CLK_TCK")
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .and_then(|raw| raw.trim().parse::<u64>().ok())?;
+        let boot_time = fs::read_to_string("/proc/stat")
+            .ok()?
+            .lines()
+            .find_map(|line| line.strip_prefix("btime "))?
+            .trim()
+            .parse::<i64>()
+            .ok()?;
+        let started_at_seconds = boot_time.checked_add((start_ticks / ticks_per_second) as i64)?;
+        let started_at_nanos =
+            ((start_ticks % ticks_per_second) * 1_000_000_000 / ticks_per_second) as u32;
+        Utc.timestamp_opt(started_at_seconds, started_at_nanos)
+            .single()
+            .map(ProcessStartTime::precise)
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    fn process_started_at(pid: u32) -> Option<ProcessStartTime> {
+        let marker = Self::proc_start_marker(pid)?;
+        let naive = NaiveDateTime::parse_from_str(&marker, "%a %b %e %H:%M:%S %Y").ok()?;
+        Some(ProcessStartTime::whole_seconds(
+            Utc.from_utc_datetime(&naive),
+        ))
+    }
+
+    #[cfg(not(unix))]
+    fn process_started_at(_pid: u32) -> Option<ProcessStartTime> {
+        None
     }
 
     fn live_project_backend_processes_path(project_root: &Path) -> PathBuf {
@@ -619,6 +696,31 @@ impl FileSystem {
         )
     }
 
+    pub fn pid_record_matches_live_process(record: &RunPidRecord) -> bool {
+        if Self::pid_record_is_authoritative(record) {
+            return Self::is_pid_alive(record);
+        }
+
+        Self::legacy_pid_record_matches_live_process(record)
+    }
+
+    pub fn legacy_pid_record_matches_live_process(record: &RunPidRecord) -> bool {
+        if Self::pid_record_is_authoritative(record) {
+            return Self::is_pid_alive(record);
+        }
+        if !Self::is_pid_running_unchecked(record.pid) {
+            return false;
+        }
+        let Some(live_started_at) = Self::process_started_at(record.pid) else {
+            return false;
+        };
+
+        // Legacy pid files without any recorded process identity can only be
+        // matched by comparing the live process start against the pid-file
+        // write timestamp. A newer live start implies PID reuse.
+        live_started_at.matches_legacy_pid_record(record.started_at)
+    }
+
     pub fn is_backend_process_alive(record: &RunBackendProcessRecord) -> bool {
         Self::process_identity_is_alive(
             record.pid,
@@ -995,10 +1097,7 @@ impl FileSystem {
 
     #[cfg(all(unix, not(target_os = "linux")))]
     fn ps_field(pid: u32, field: &str) -> Option<String> {
-        let output = Command::new("ps")
-            .args(["-o", &format!("{field}="), "-p", &pid.to_string()])
-            .output()
-            .ok()?;
+        let output = Self::ps_command(pid, field).output().ok()?;
         if !output.status.success() {
             return None;
         }
@@ -1009,6 +1108,17 @@ impl FileSystem {
         } else {
             Some(trimmed.to_owned())
         }
+    }
+
+    #[cfg(any(test, all(unix, not(target_os = "linux"))))]
+    fn ps_command(pid: u32, field: &str) -> Command {
+        let mut command = Command::new("ps");
+        command
+            .env("LC_ALL", "C")
+            .env("LANG", "C")
+            .env("TZ", "UTC")
+            .args(["-o", &format!("{field}="), "-p", &pid.to_string()]);
+        command
     }
 
     pub(crate) fn mirror_project_file(
@@ -5504,7 +5614,11 @@ mod tests {
         assert_eq!(read_back.run_id.as_deref(), Some("run-1"));
         assert_eq!(read_back.run_started_at, written.run_started_at);
         assert_eq!(read_back.proc_start_marker, written.proc_start_marker);
+        #[cfg(target_os = "linux")]
         assert!(FileSystem::is_pid_alive(&read_back));
+
+        #[cfg(any(not(unix), all(unix, not(target_os = "linux"))))]
+        assert!(!FileSystem::is_pid_alive(&read_back));
 
         FileSystem::remove_pid_file(temp.path(), &project_id).expect("remove pid file");
         assert!(FileSystem::read_pid_file(temp.path(), &project_id)
@@ -5541,8 +5655,25 @@ mod tests {
             "run-1",
             run_started_at
         ));
-        assert!(FileSystem::backend_process_is_authoritative(&tracked));
-        assert!(FileSystem::is_backend_process_alive(&tracked));
+        #[cfg(target_os = "linux")]
+        {
+            assert!(FileSystem::backend_process_is_authoritative(&tracked));
+            assert!(FileSystem::is_backend_process_alive(&tracked));
+        }
+
+        #[cfg(all(unix, not(target_os = "linux")))]
+        {
+            assert!(tracked.proc_start_ticks.is_none());
+            assert!(tracked.proc_start_marker.is_some());
+            assert!(FileSystem::backend_process_is_authoritative(&tracked));
+            assert!(FileSystem::is_backend_process_alive(&tracked));
+        }
+
+        #[cfg(not(unix))]
+        {
+            assert!(!FileSystem::backend_process_is_authoritative(&tracked));
+            assert!(!FileSystem::is_backend_process_alive(&tracked));
+        }
 
         FileSystem::remove_backend_process(&project_root, tracked.pid)
             .expect("remove backend process");
@@ -5631,6 +5762,43 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn legacy_pid_liveness_accepts_same_live_process_when_recorded_after_start() {
+        let record = RunPidRecord {
+            pid: std::process::id(),
+            started_at: Utc::now(),
+            owner: RunPidOwner::Cli,
+            writer_owner: None,
+            run_id: None,
+            run_started_at: None,
+            proc_start_ticks: None,
+            proc_start_marker: None,
+        };
+
+        assert!(FileSystem::legacy_pid_record_matches_live_process(&record));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn legacy_pid_liveness_rejects_live_process_started_after_record_timestamp() {
+        let record = RunPidRecord {
+            pid: std::process::id(),
+            started_at: Utc::now() - chrono::Duration::days(365),
+            owner: RunPidOwner::Cli,
+            writer_owner: None,
+            run_id: None,
+            run_started_at: None,
+            proc_start_ticks: None,
+            proc_start_marker: None,
+        };
+
+        assert!(
+            !FileSystem::legacy_pid_record_matches_live_process(&record),
+            "legacy pid records must not treat a newer process as the original owner after pid reuse"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn pid_liveness_rejects_mismatched_start_ticks() {
@@ -5672,13 +5840,13 @@ mod tests {
         #[cfg(all(unix, not(target_os = "linux")))]
         assert!(FileSystem::pid_record_is_authoritative(&record));
 
-        #[cfg(any(target_os = "linux", not(unix)))]
+        #[cfg(not(all(unix, not(target_os = "linux"))))]
         assert!(!FileSystem::pid_record_is_authoritative(&record));
     }
 
     #[cfg(all(unix, not(target_os = "linux")))]
     #[test]
-    fn pid_liveness_accepts_matching_start_marker_on_non_linux_unix() {
+    fn marker_only_pid_records_match_live_marker_on_non_linux_unix() {
         let record = RunPidRecord {
             pid: std::process::id(),
             started_at: Utc::now(),
@@ -5687,31 +5855,84 @@ mod tests {
             run_id: None,
             run_started_at: None,
             proc_start_ticks: None,
-            proc_start_marker: FileSystem::proc_start_marker(std::process::id()),
+            proc_start_marker: FileSystem::proc_start_marker_for_pid(std::process::id()),
         };
 
         assert!(FileSystem::pid_record_is_authoritative(&record));
         assert!(FileSystem::is_pid_alive(&record));
+        assert!(FileSystem::pid_record_matches_live_process(&record));
     }
 
     #[cfg(all(unix, not(target_os = "linux")))]
     #[test]
-    fn pid_liveness_rejects_mismatched_start_marker_on_non_linux_unix() {
+    fn legacy_pid_liveness_accepts_same_second_live_process_on_non_linux_unix() {
+        let live_started_at =
+            FileSystem::process_started_at(std::process::id()).expect("process start time");
         let record = RunPidRecord {
             pid: std::process::id(),
-            started_at: Utc::now(),
+            started_at: live_started_at.started_at + chrono::Duration::milliseconds(900),
             owner: RunPidOwner::Cli,
             writer_owner: None,
             run_id: None,
             run_started_at: None,
             proc_start_ticks: None,
-            proc_start_marker: Some("mismatched-start-marker".to_owned()),
+            proc_start_marker: None,
         };
 
         assert!(
             !FileSystem::is_pid_alive(&record),
-            "mismatched proc_start_marker should reject reused or stale pid records"
+            "legacy pid records without identity fields must not be treated as authoritative"
         );
+        assert!(FileSystem::legacy_pid_record_matches_live_process(&record));
+    }
+
+    #[test]
+    fn coarse_process_start_precision_accepts_same_second_legacy_recovery() {
+        let live_started_at = Utc
+            .with_ymd_and_hms(2026, 4, 11, 12, 0, 0)
+            .single()
+            .expect("timestamp");
+        let recorded_at = live_started_at + chrono::Duration::milliseconds(900);
+
+        assert!(
+            ProcessStartTime::whole_seconds(live_started_at).matches_legacy_pid_record(recorded_at)
+        );
+    }
+
+    #[test]
+    fn precise_process_start_precision_accepts_legacy_recorded_after_start() {
+        let live_started_at = Utc
+            .with_ymd_and_hms(2026, 4, 11, 12, 0, 0)
+            .single()
+            .expect("timestamp")
+            + chrono::Duration::milliseconds(100);
+        let recorded_at = live_started_at + chrono::Duration::milliseconds(800);
+
+        assert!(ProcessStartTime::precise(live_started_at).matches_legacy_pid_record(recorded_at));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ps_command_forces_c_locale_and_utc() {
+        let command = FileSystem::ps_command(42, "lstart");
+        let args = command
+            .get_args()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        let envs = command
+            .get_envs()
+            .map(|(key, value)| {
+                (
+                    key.to_string_lossy().into_owned(),
+                    value.map(|value| value.to_string_lossy().into_owned()),
+                )
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+
+        assert_eq!(args, vec!["-o", "lstart=", "-p", "42"]);
+        assert_eq!(envs.get("LC_ALL"), Some(&Some("C".to_owned())));
+        assert_eq!(envs.get("LANG"), Some(&Some("C".to_owned())));
+        assert_eq!(envs.get("TZ"), Some(&Some("UTC".to_owned())));
     }
 
     #[test]

--- a/src/adapters/fs.rs
+++ b/src/adapters/fs.rs
@@ -292,13 +292,10 @@ impl FileSystem {
     #[cfg(target_os = "linux")]
     fn process_started_at(pid: u32) -> Option<ProcessStartTime> {
         let start_ticks = Self::proc_start_ticks(pid)?;
-        let ticks_per_second = Command::new("getconf")
-            .arg("CLK_TCK")
-            .output()
-            .ok()
-            .filter(|output| output.status.success())
-            .and_then(|output| String::from_utf8(output.stdout).ok())
-            .and_then(|raw| raw.trim().parse::<u64>().ok())?;
+        // CLK_TCK is 100 on virtually all Linux kernels (set at compile
+        // time, almost never changed).  Avoid shelling out to `getconf`
+        // which may not exist in slim containers.
+        let ticks_per_second: u64 = 100;
         let boot_time = fs::read_to_string("/proc/stat")
             .ok()?
             .lines()
@@ -5649,7 +5646,11 @@ mod tests {
         #[cfg(target_os = "linux")]
         assert!(FileSystem::is_pid_alive(&read_back));
 
-        #[cfg(any(not(unix), all(unix, not(target_os = "linux"))))]
+        // On non-Linux Unix, marker-only records are now authoritative.
+        #[cfg(all(unix, not(target_os = "linux")))]
+        assert!(FileSystem::is_pid_alive(&read_back));
+
+        #[cfg(not(unix))]
         assert!(!FileSystem::is_pid_alive(&read_back));
 
         FileSystem::remove_pid_file(temp.path(), &project_id).expect("remove pid file");

--- a/src/adapters/fs.rs
+++ b/src/adapters/fs.rs
@@ -267,10 +267,19 @@ impl FileSystem {
 
         #[cfg(all(unix, not(target_os = "linux")))]
         {
-            return matches!(
-                (proc_start_marker, Self::proc_start_marker(pid)),
-                (Some(expected_marker), Some(actual_marker)) if actual_marker == expected_marker
-            );
+            if let (Some(expected), Some(actual)) = (proc_start_marker, Self::proc_start_marker(pid))
+            {
+                if actual == expected {
+                    return true;
+                }
+                // Backward compat: old records may have been written under a
+                // different locale/TZ.  Fall back to a raw `ps` call without
+                // locale normalization and accept either format.
+                if let Some(raw_actual) = Self::proc_start_marker_raw(pid) {
+                    return raw_actual == expected;
+                }
+            }
+            return false;
         }
 
         #[cfg(not(all(unix, not(target_os = "linux"))))]
@@ -1073,8 +1082,31 @@ impl FileSystem {
         Self::ps_field(pid, "lstart")
     }
 
+    /// Raw marker without `LC_ALL=C TZ=UTC` normalization — used as a
+    /// backward-compatibility fallback when comparing against records
+    /// written by older binaries under a different locale/timezone.
+    #[cfg(all(unix, not(target_os = "linux")))]
+    fn proc_start_marker_raw(pid: u32) -> Option<String> {
+        let output = Command::new("ps")
+            .args(["-o", "lstart=", "-p", &pid.to_string()])
+            .output()
+            .ok()?;
+        let value = String::from_utf8_lossy(&output.stdout);
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_owned())
+        }
+    }
+
     #[cfg(any(target_os = "linux", not(unix)))]
     fn proc_start_marker(_pid: u32) -> Option<String> {
+        None
+    }
+
+    #[cfg(any(target_os = "linux", not(unix)))]
+    fn proc_start_marker_raw(_pid: u32) -> Option<String> {
         None
     }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1539,8 +1539,8 @@ fn classify_running_snapshot_liveness(
 ) -> AppResult<RunningSnapshotLiveness> {
     let pid_record = FileSystem::read_pid_file(base_dir, project_id)?;
     if let Some(record) = pid_record.as_ref() {
-        if FileSystem::pid_record_is_authoritative(record) {
-            if FileSystem::is_pid_alive(record) {
+        if FileSystem::pid_record_matches_live_process(record) {
+            if FileSystem::pid_record_is_authoritative(record) {
                 return Ok(
                     match (
                         record.owner.clone(),
@@ -1561,16 +1561,16 @@ fn classify_running_snapshot_liveness(
                     },
                 );
             }
-            return Ok(RunningSnapshotLiveness::Stale);
-        }
-
-        if FileSystem::is_pid_running_unchecked(record.pid) {
             return Ok(match record.owner {
                 crate::adapters::fs::RunPidOwner::Cli => RunningSnapshotLiveness::LegacyCliProcess,
                 crate::adapters::fs::RunPidOwner::Daemon => {
                     RunningSnapshotLiveness::LegacyDaemonProcess
                 }
             });
+        }
+
+        if FileSystem::pid_record_is_authoritative(record) {
+            return Ok(RunningSnapshotLiveness::Stale);
         }
     }
 
@@ -2286,10 +2286,6 @@ impl TrackedDescendantProcess {
     }
 
     fn matches_live_process(&self) -> bool {
-        if self.proc_start_ticks.is_none() && self.proc_start_marker.is_none() {
-            return FileSystem::is_pid_running_unchecked(self.pid);
-        }
-
         FileSystem::is_pid_alive(&crate::adapters::fs::RunPidRecord {
             pid: self.pid,
             started_at: Utc::now(),
@@ -6786,6 +6782,52 @@ mod tests {
             !FileSystem::is_pid_running_unchecked(child_pid),
             "tracked cleanup should remove the orphaned child process"
         );
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    #[test]
+    fn tracked_descendant_process_matches_live_marker_only_identity() {
+        let tracked = super::TrackedDescendantProcess {
+            pid: std::process::id(),
+            proc_start_ticks: None,
+            proc_start_marker: FileSystem::proc_start_marker_for_pid(std::process::id()),
+        };
+        assert!(tracked.matches_live_process());
+
+        let mismatched = super::TrackedDescendantProcess {
+            proc_start_marker: Some("mismatched-start-marker".to_owned()),
+            ..tracked
+        };
+        assert!(!mismatched.matches_live_process());
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    #[test]
+    fn classify_running_snapshot_liveness_treats_marker_only_current_pid_file_as_cli_process() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let project_id = ProjectId::new("marker-only-current-run".to_owned()).expect("project id");
+        let run_started_at = Utc::now();
+        let pid_record = FileSystem::write_pid_file(
+            temp_dir.path(),
+            &project_id,
+            crate::adapters::fs::RunPidOwner::Cli,
+            Some("writer-alpha"),
+            Some("run-1"),
+            Some(run_started_at),
+        )
+        .expect("write pid file");
+
+        assert!(pid_record.proc_start_ticks.is_none());
+        assert!(pid_record.proc_start_marker.is_some());
+
+        match super::classify_running_snapshot_liveness(temp_dir.path(), &project_id)
+            .expect("classify liveness")
+        {
+            super::RunningSnapshotLiveness::CliProcess(record) => {
+                assert_eq!(record.run_id.as_deref(), Some("run-1"));
+            }
+            _ => panic!("expected marker-only pid file to be treated as the live CLI process"),
+        }
     }
 }
 

--- a/src/contexts/project_run_record/queries.rs
+++ b/src/contexts/project_run_record/queries.rs
@@ -46,13 +46,12 @@ fn running_attempt_boundary_sequence(
                 )
         })
         .map(|event| event.sequence);
-    let snapshot_boundary = active_run_started_at(snapshot).map(|started_at| {
+    let snapshot_boundary = active_run_started_at(snapshot).and_then(|started_at| {
         events
             .iter()
             .filter(|event| event_run_id(event) == Some(run_id) && event.timestamp < started_at)
             .map(|event| event.sequence)
             .max()
-            .unwrap_or(0)
     });
 
     durable_boundary.into_iter().chain(snapshot_boundary).max()

--- a/src/contexts/project_run_record/queries.rs
+++ b/src/contexts/project_run_record/queries.rs
@@ -54,7 +54,17 @@ fn running_attempt_boundary_sequence(
             .max()
     });
 
-    durable_boundary.into_iter().chain(snapshot_boundary).max()
+    // If we found a start/resume event or a snapshot-based boundary, use it.
+    // Otherwise fall back to 0 so terminal events are still visible — this
+    // covers the case where run_started was never durably appended but a
+    // terminal event (run_failed/run_completed) was.
+    Some(
+        durable_boundary
+            .into_iter()
+            .chain(snapshot_boundary)
+            .max()
+            .unwrap_or(0),
+    )
 }
 
 /// Returns the durable terminal status for the current running attempt, if any.

--- a/src/contexts/workflow_composition/engine.rs
+++ b/src/contexts/workflow_composition/engine.rs
@@ -734,7 +734,7 @@ fn preserve_interrupted_run(snapshot: &mut RunSnapshot) {
 
 fn orchestrator_process_is_alive(base_dir: &Path, project_id: &ProjectId) -> AppResult<bool> {
     Ok(FileSystem::read_pid_file(base_dir, project_id)?
-        .is_some_and(|record| FileSystem::is_pid_alive(&record)))
+        .is_some_and(|record| FileSystem::pid_record_matches_live_process(&record)))
 }
 
 pub struct InterruptedRunUpdate<'a> {
@@ -8349,10 +8349,16 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::adapters::fs::{
-        FileSystem, FsMilestoneControllerStore, FsMilestoneJournalStore, FsMilestonePlanStore,
-        FsMilestoneSnapshotStore, FsMilestoneStore, RunPidOwner,
+        FileSystem, FsArtifactStore, FsJournalStore, FsMilestoneControllerStore,
+        FsMilestoneJournalStore, FsMilestonePlanStore, FsMilestoneSnapshotStore, FsMilestoneStore,
+        FsPayloadArtifactWriteStore, FsProjectStore, FsRawOutputStore, FsRunSnapshotStore,
+        FsRunSnapshotWriteStore, FsRuntimeLogWriteStore, FsSessionStore, RunPidOwner, RunPidRecord,
+    };
+    use crate::contexts::agent_execution::model::{
+        InvocationEnvelope, InvocationMetadata, InvocationRequest, RawOutputReference, TokenCounts,
     };
     use crate::contexts::agent_execution::policy::ResolvedPanelMember;
+    use crate::contexts::agent_execution::{AgentExecutionPort, AgentExecutionService};
     use crate::contexts::milestone_record::bundle::{
         AcceptanceCriterion, BeadProposal, MilestoneBundle, MilestoneIdentity, Workstream,
     };
@@ -8367,8 +8373,9 @@ mod tests {
         TaskOrigin, TaskSource,
     };
     use crate::contexts::project_run_record::service::{
-        JournalStorePort, RunSnapshotPort, RunSnapshotWritePort,
+        create_project, CreateProjectInput, JournalStorePort, RunSnapshotPort, RunSnapshotWritePort,
     };
+    use crate::contexts::workflow_composition::retry_policy::RetryPolicy;
     use crate::contexts::workspace_governance::{initialize_workspace, EffectiveConfig};
     use crate::shared::domain::{
         BackendFamily, FlowPreset, ProjectId, ResolvedBackendTarget, StageId,
@@ -8378,8 +8385,8 @@ mod tests {
     use super::{
         build_final_review_snapshot, complete_run, drift_still_satisfies_requirements,
         mark_running_run_interrupted, milestone_lineage_plan_hash, pause_run,
-        resolution_has_drifted, sync_milestone_bead_start, InterruptedRunContext,
-        InterruptedRunUpdate, RunningAttemptIdentity,
+        resolution_has_drifted, resume_run_with_retry, sync_milestone_bead_start,
+        InterruptedRunContext, InterruptedRunUpdate, RunningAttemptIdentity,
     };
 
     fn final_review_reviewers() -> Vec<ResolvedPanelMember> {
@@ -8966,6 +8973,47 @@ mod tests {
 
     struct NoPendingAmendmentQueue;
 
+    #[derive(Clone, Default)]
+    struct NoopAgentExecutionAdapter;
+
+    impl AgentExecutionPort for NoopAgentExecutionAdapter {
+        async fn check_capability(
+            &self,
+            _backend: &ResolvedBackendTarget,
+            _contract: &crate::contexts::agent_execution::InvocationContract,
+        ) -> AppResult<()> {
+            Ok(())
+        }
+
+        async fn check_availability(&self, _backend: &ResolvedBackendTarget) -> AppResult<()> {
+            Ok(())
+        }
+
+        async fn invoke(&self, request: InvocationRequest) -> AppResult<InvocationEnvelope> {
+            Ok(InvocationEnvelope {
+                raw_output_reference: RawOutputReference::Inline(r#"{"status":"ok"}"#.to_owned()),
+                parsed_payload: serde_json::json!({"status": "ok"}),
+                metadata: InvocationMetadata {
+                    invocation_id: request.invocation_id,
+                    duration: std::time::Duration::ZERO,
+                    token_counts: TokenCounts::default(),
+                    backend_used: request.resolved_target.backend.clone(),
+                    model_used: request.resolved_target.model.clone(),
+                    adapter_reported_backend: None,
+                    adapter_reported_model: None,
+                    attempt_number: 0,
+                    session_id: None,
+                    session_reused: false,
+                },
+                timestamp: Utc::now(),
+            })
+        }
+
+        async fn cancel(&self, _invocation_id: &str) -> AppResult<()> {
+            Ok(())
+        }
+    }
+
     impl crate::contexts::project_run_record::service::AmendmentQueuePort for NoPendingAmendmentQueue {
         fn write_amendment(
             &self,
@@ -9052,6 +9100,110 @@ mod tests {
             status_summary: "running: planning".to_owned(),
             last_stage_resolution_snapshot: None,
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resume_run_with_retry_keeps_live_legacy_pid_only_snapshot_running() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+
+        runtime.block_on(async {
+            let temp_dir = tempdir().expect("create temp dir");
+            initialize_workspace(temp_dir.path(), Utc::now()).expect("initialize workspace");
+            let effective_config =
+                EffectiveConfig::load(temp_dir.path()).expect("load effective config");
+            let project_id = ProjectId::new("resume-live-legacy-pid").expect("project id");
+            let created_at = Utc::now();
+
+            create_project(
+                &FsProjectStore,
+                &FsJournalStore,
+                temp_dir.path(),
+                CreateProjectInput {
+                    id: project_id.clone(),
+                    name: "Resume legacy pid".to_owned(),
+                    flow: FlowPreset::Standard,
+                    prompt_path: "prompt.md".to_owned(),
+                    prompt_contents: "prompt".to_owned(),
+                    prompt_hash: "prompt-hash".to_owned(),
+                    created_at,
+                    task_source: None,
+                },
+            )
+            .expect("create project");
+
+            let run_id =
+                crate::shared::domain::RunId::new("run-resume-live-legacy-pid").expect("run id");
+            let mut snapshot = running_snapshot_for_pid_cleanup(&run_id);
+            let run_started_at = Utc::now();
+            snapshot
+                .active_run
+                .as_mut()
+                .expect("active run")
+                .started_at = run_started_at;
+            FsRunSnapshotWriteStore
+                .write_run_snapshot(temp_dir.path(), &project_id, &snapshot)
+                .expect("write running snapshot");
+
+            let legacy_pid_record = RunPidRecord {
+                pid: std::process::id(),
+                started_at: Utc::now(),
+                owner: RunPidOwner::Cli,
+                writer_owner: None,
+                run_id: None,
+                run_started_at: None,
+                proc_start_ticks: None,
+                proc_start_marker: None,
+            };
+            FileSystem::write_atomic(
+                &FileSystem::live_project_root(temp_dir.path(), &project_id).join("run.pid"),
+                &serde_json::to_string_pretty(&legacy_pid_record).expect("serialize pid file"),
+            )
+            .expect("write legacy pid file");
+
+            let agent_service =
+                AgentExecutionService::new(NoopAgentExecutionAdapter, FsRawOutputStore, FsSessionStore);
+            let error = resume_run_with_retry(
+                &agent_service,
+                &FsRunSnapshotStore,
+                &FsRunSnapshotWriteStore,
+                &FsJournalStore,
+                &FsArtifactStore,
+                &FsPayloadArtifactWriteStore,
+                &FsRuntimeLogWriteStore,
+                &NoPendingAmendmentQueue,
+                temp_dir.path(),
+                None,
+                &project_id,
+                None,
+                FlowPreset::Standard,
+                &effective_config,
+                &RetryPolicy::default_policy(),
+                crate::contexts::agent_execution::CancellationToken::new(),
+            )
+            .await
+            .expect_err("live legacy pid should block resume instead of reconciling to failed");
+
+            assert!(matches!(
+                error,
+                AppError::ResumeFailed { reason }
+                    if reason == "project already has a running run; `run resume` only works from failed or paused snapshots"
+            ));
+
+            let final_snapshot = FsRunSnapshotStore
+                .read_run_snapshot(temp_dir.path(), &project_id)
+                .expect("read final snapshot");
+            assert_eq!(final_snapshot.status, RunStatus::Running);
+            assert!(
+                FileSystem::read_pid_file(temp_dir.path(), &project_id)
+                    .expect("read pid file")
+                    .is_some(),
+                "resume should keep a live legacy pid record instead of reconciling it away"
+            );
+        });
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -171,6 +171,14 @@ fn live_pid_record_json(
     {
         record["proc_start_ticks"] = serde_json::json!(proc_start_ticks(pid));
     }
+    #[cfg(all(unix, not(target_os = "linux")))]
+    {
+        if let Some(marker) =
+            ralph_burning::adapters::fs::FileSystem::proc_start_marker_for_pid(pid)
+        {
+            record["proc_start_marker"] = serde_json::json!(marker);
+        }
+    }
     record
 }
 
@@ -6025,6 +6033,54 @@ fn run_status_keeps_legacy_cli_owned_running_snapshot_active_with_live_pid_witho
     assert!(
         !stdout.contains("stale"),
         "live legacy pid-only records must not be auto-recovered while the orchestrator pid still exists: {stdout}"
+    );
+}
+
+#[test]
+fn run_status_treats_legacy_pid_record_as_stale_when_live_process_started_after_record() {
+    let temp_dir = initialize_workspace_fixture();
+    create_project_fixture(temp_dir.path(), "alpha");
+    select_active_project_fixture(temp_dir.path(), "alpha");
+
+    fs::write(
+        project_root(temp_dir.path(), "alpha").join("run.json"),
+        r#"{
+  "active_run": {
+    "run_id": "run-legacy-pid-reused-status",
+    "stage_cursor": { "stage": "implementation", "cycle": 1, "attempt": 1, "completion_round": 1 },
+    "started_at": "2026-04-10T00:00:00Z"
+  },
+  "status": "running",
+  "cycle_history": [],
+  "completion_rounds": 1,
+  "rollback_point_meta": { "last_rollback_id": null, "rollback_count": 0 },
+  "amendment_queue": { "pending": [], "processed_count": 0 },
+  "status_summary": "running: Implementation"
+}"#,
+    )
+    .expect("write running snapshot");
+    fs::write(
+        project_root(temp_dir.path(), "alpha").join("run.pid"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "pid": std::process::id(),
+            "started_at": Utc::now() - Duration::days(365),
+            "owner": "cli",
+        }))
+        .expect("serialize legacy pid"),
+    )
+    .expect("write legacy pid");
+
+    let output = Command::new(binary())
+        .args(["run", "status"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run status");
+
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Status: stale (process not found)"),
+        "legacy pid records must be treated as stale when the live process started after the recorded timestamp: {stdout}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Honor `proc_start_marker` on non-Linux Unix (macOS/BSD) for PID identity verification
- Detect PID reuse by comparing live process start time against recorded timestamp
- Treat legacy pid files (no start-time fields) with safe fallback heuristics
- Cross-platform liveness classification in `run status`, `run resume`, `run stop`

## Known limitations (tracked as follow-up beads)
- Non-Linux marker has whole-second granularity — PID reuse within same second accepted (rlm.2 scope)
- The cross-platform design was partially implemented over 9 ralph-burning rounds with oscillation between marker/ticks approaches — may need further refinement

## Test plan
- [x] New CLI integration tests for cross-platform liveness
- [x] Rebased cleanly on master (includes rlm-1 changes)
- [x] Compiles without errors