### PR TITLE
chore(config): update Claude model references from 4.6 to 4.7

### DIFF
--- a/src/contexts/agent_execution/service.rs
+++ b/src/contexts/agent_execution/service.rs
@@ -535,7 +535,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn invoke_preserves_adapter_reported_values_before_normalizing_target() {
         let temp_dir = tempdir().expect("create temp dir");
-        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-6");
+        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-7");
         let request = request_fixture(temp_dir.path().to_path_buf(), resolved_target.clone());
         let service = AgentExecutionService::new(
             ReportingAdapter::new(
@@ -549,7 +549,7 @@ mod tests {
         let envelope = service.invoke(request).await.expect("invoke succeeds");
 
         assert_eq!(envelope.metadata.backend_used.family, BackendFamily::Claude);
-        assert_eq!(envelope.metadata.model_used.model_id, "claude-opus-4-6");
+        assert_eq!(envelope.metadata.model_used.model_id, "claude-opus-4-7");
         assert_eq!(
             envelope
                 .metadata
@@ -572,7 +572,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn invoke_always_populates_adapter_reported_values() {
         let temp_dir = tempdir().expect("create temp dir");
-        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-6");
+        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-7");
         let request = request_fixture(temp_dir.path().to_path_buf(), resolved_target.clone());
         let service = AgentExecutionService::new(
             ReportingAdapter::new(
@@ -600,9 +600,9 @@ mod tests {
                 .adapter_reported_model
                 .as_ref()
                 .map(|m| m.model_id.as_str()),
-            Some("claude-opus-4-6")
+            Some("claude-opus-4-7")
         );
         assert_eq!(envelope.metadata.backend_used.family, BackendFamily::Claude);
-        assert_eq!(envelope.metadata.model_used.model_id, "claude-opus-4-6");
+        assert_eq!(envelope.metadata.model_used.model_id, "claude-opus-4-7");
     }
 }

--- a/src/contexts/conformance_spec/scenarios.rs
+++ b/src/contexts/conformance_spec/scenarios.rs
@@ -10833,9 +10833,9 @@ fn register_workflow_panels(m: &mut HashMap<String, ScenarioExecutor>) {
         // Verify producer metadata serializes correctly.
         let producer = RecordProducer::Agent {
             requested_backend_family: "claude".to_owned(),
-            requested_model_id: "claude-opus-4-6".to_owned(),
+            requested_model_id: "claude-opus-4-7".to_owned(),
             actual_backend_family: "claude".to_owned(),
-            actual_model_id: "claude-opus-4-6".to_owned(),
+            actual_model_id: "claude-opus-4-7".to_owned(),
         };
         let producer_json =
             serde_json::to_value(&producer).map_err(|e| format!("producer serialize: {e}"))?;
@@ -11195,7 +11195,7 @@ fn register_workflow_panels(m: &mut HashMap<String, ScenarioExecutor>) {
                 exhausted_count: 0,
                 probe_exhausted_count: 0,
                 executed_voters: vec![
-                    "claude:claude-opus-4-6".to_owned(),
+                    "claude:claude-opus-4-7".to_owned(),
                     "codex:codex-1".to_owned(),
                 ],
             };
@@ -11324,7 +11324,7 @@ fn register_workflow_panels(m: &mut HashMap<String, ScenarioExecutor>) {
             exhausted_count: 0,
             probe_exhausted_count: 0,
             executed_voters: vec![
-                "claude:claude-opus-4-6".to_owned(),
+                "claude:claude-opus-4-7".to_owned(),
                 "codex:codex-1".to_owned(),
             ],
         };
@@ -11688,7 +11688,7 @@ fn register_workflow_panels(m: &mut HashMap<String, ScenarioExecutor>) {
             // ── Helper assertions ──
             let old_target = ResolvedBackendTarget::new(
                 crate::shared::domain::BackendFamily::Claude,
-                "claude-opus-4-6".to_owned(),
+                "claude-opus-4-7".to_owned(),
             );
             let new_target = ResolvedBackendTarget::new(
                 crate::shared::domain::BackendFamily::Codex,
@@ -11796,7 +11796,7 @@ fn register_workflow_panels(m: &mut HashMap<String, ScenarioExecutor>) {
         );
         let new_target = ResolvedBackendTarget::new(
             crate::shared::domain::BackendFamily::Claude,
-            "claude-opus-4-6".to_owned(),
+            "claude-opus-4-7".to_owned(),
         );
         let old = build_single_target_snapshot(StageId::AcceptanceQa, &old_target);
         let new = build_single_target_snapshot(StageId::AcceptanceQa, &new_target);
@@ -11862,7 +11862,7 @@ fn register_workflow_panels(m: &mut HashMap<String, ScenarioExecutor>) {
             // ── Helper: model-level drift within same family ──
             let old_target = ResolvedBackendTarget::new(
                 crate::shared::domain::BackendFamily::Claude,
-                "claude-opus-4-6".to_owned(),
+                "claude-opus-4-7".to_owned(),
             );
             let new_target = ResolvedBackendTarget::new(
                 crate::shared::domain::BackendFamily::Claude,
@@ -11942,7 +11942,7 @@ fn register_workflow_panels(m: &mut HashMap<String, ScenarioExecutor>) {
             // ── Helper: completer model change drift ──
             let target_a = ResolvedBackendTarget::new(
                 crate::shared::domain::BackendFamily::Claude,
-                "claude-opus-4-6".to_owned(),
+                "claude-opus-4-7".to_owned(),
             );
             let target_b = ResolvedBackendTarget::new(
                 crate::shared::domain::BackendFamily::Codex,

--- a/src/contexts/workflow_composition/mod.rs
+++ b/src/contexts/workflow_composition/mod.rs
@@ -283,7 +283,7 @@ mod tests {
             duration: Duration::from_millis(1),
             token_counts: TokenCounts::default(),
             backend_used: BackendSpec::from_family(BackendFamily::Claude),
-            model_used: ModelSpec::new(BackendFamily::Claude, "claude-opus-4-6"),
+            model_used: ModelSpec::new(BackendFamily::Claude, "claude-opus-4-7"),
             adapter_reported_backend: None,
             adapter_reported_model: None,
             attempt_number: 1,
@@ -295,9 +295,9 @@ mod tests {
             agent_record_producer(&metadata),
             RecordProducer::Agent {
                 requested_backend_family: "claude".to_owned(),
-                requested_model_id: "claude-opus-4-6".to_owned(),
+                requested_model_id: "claude-opus-4-7".to_owned(),
                 actual_backend_family: "claude".to_owned(),
-                actual_model_id: "claude-opus-4-6".to_owned(),
+                actual_model_id: "claude-opus-4-7".to_owned(),
             }
         );
     }
@@ -309,7 +309,7 @@ mod tests {
             duration: Duration::from_millis(1),
             token_counts: TokenCounts::default(),
             backend_used: BackendSpec::from_family(BackendFamily::Claude),
-            model_used: ModelSpec::new(BackendFamily::Claude, "claude-opus-4-6"),
+            model_used: ModelSpec::new(BackendFamily::Claude, "claude-opus-4-7"),
             adapter_reported_backend: Some(BackendSpec::from_family(BackendFamily::OpenRouter)),
             adapter_reported_model: Some(ModelSpec::new(
                 BackendFamily::OpenRouter,
@@ -324,7 +324,7 @@ mod tests {
             agent_record_producer(&metadata),
             RecordProducer::Agent {
                 requested_backend_family: "claude".to_owned(),
-                requested_model_id: "claude-opus-4-6".to_owned(),
+                requested_model_id: "claude-opus-4-7".to_owned(),
                 actual_backend_family: "openrouter".to_owned(),
                 actual_model_id: "openai/gpt-4.1".to_owned(),
             }
@@ -335,9 +335,9 @@ mod tests {
     fn require_agent_record_producer_returns_actual_backend_and_model() {
         let producer = RecordProducer::Agent {
             requested_backend_family: "claude".to_owned(),
-            requested_model_id: "claude-opus-4-6".to_owned(),
+            requested_model_id: "claude-opus-4-7".to_owned(),
             actual_backend_family: "claude".to_owned(),
-            actual_model_id: "claude-opus-4-6".to_owned(),
+            actual_model_id: "claude-opus-4-7".to_owned(),
         };
 
         assert_eq!(
@@ -348,7 +348,7 @@ mod tests {
                 "completion panel invocations must produce agent metadata",
             )
             .expect("agent producer"),
-            ("claude", "claude-opus-4-6")
+            ("claude", "claude-opus-4-7")
         );
     }
 
@@ -356,7 +356,7 @@ mod tests {
     fn require_agent_record_producer_returns_actual_when_different_from_requested() {
         let producer = RecordProducer::Agent {
             requested_backend_family: "claude".to_owned(),
-            requested_model_id: "claude-opus-4-6".to_owned(),
+            requested_model_id: "claude-opus-4-7".to_owned(),
             actual_backend_family: "openrouter".to_owned(),
             actual_model_id: "openai/gpt-4.1".to_owned(),
         };
@@ -377,7 +377,7 @@ mod tests {
     fn require_agent_record_producer_falls_back_to_requested_when_actual_missing() {
         let producer = RecordProducer::Agent {
             requested_backend_family: "claude".to_owned(),
-            requested_model_id: "claude-opus-4-6".to_owned(),
+            requested_model_id: "claude-opus-4-7".to_owned(),
             actual_backend_family: String::new(),
             actual_model_id: String::new(),
         };
@@ -390,7 +390,7 @@ mod tests {
                 "completion panel invocations must produce agent metadata",
             )
             .expect("agent producer"),
-            ("claude", "claude-opus-4-6")
+            ("claude", "claude-opus-4-7")
         );
     }
 

--- a/src/contexts/workspace_governance/config.rs
+++ b/src/contexts/workspace_governance/config.rs
@@ -1485,7 +1485,7 @@ fn default_final_review_backends() -> Vec<PanelBackendSpec> {
         )),
         PanelBackendSpec::optional_selection(BackendSelection::new(
             BackendFamily::Claude,
-            Some("claude-opus-4-6-max".to_owned()),
+            Some("claude-opus-4-7-max".to_owned()),
         )),
         PanelBackendSpec::optional_selection(BackendSelection::new(
             BackendFamily::Codex,
@@ -1537,7 +1537,7 @@ fn default_backend_runtime_settings(backend_name: &str) -> AppResult<BackendRunt
                 ..Default::default()
             },
             "claude" => BackendRoleModels {
-                final_reviewer: Some("claude-opus-4-6-max".to_owned()),
+                final_reviewer: Some("claude-opus-4-7-max".to_owned()),
                 ..Default::default()
             },
             _ => BackendRoleModels::default(),

--- a/src/shared/domain.rs
+++ b/src/shared/domain.rs
@@ -82,7 +82,7 @@ impl BackendFamily {
 
     pub fn default_model_id(self) -> &'static str {
         match self {
-            Self::Claude => "claude-opus-4-6",
+            Self::Claude => "claude-opus-4-7",
             Self::Codex => "gpt-5.4",
             Self::OpenRouter => "openai/gpt-5.4",
             Self::Stub => "stub-default",
@@ -251,14 +251,14 @@ impl BackendRole {
 
     pub fn default_target(self) -> ResolvedBackendTarget {
         match self {
-            Self::Planner => ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-6"),
+            Self::Planner => ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-7"),
             Self::Implementer => ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4-high"),
             Self::Reviewer => ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4"),
             Self::QaValidator => {
                 ResolvedBackendTarget::new(BackendFamily::OpenRouter, "openai/gpt-5.4")
             }
             Self::CompletionJudge => {
-                ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-6")
+                ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-7")
             }
         }
     }

--- a/tests/unit/agent_execution_test.rs
+++ b/tests/unit/agent_execution_test.rs
@@ -224,7 +224,7 @@ async fn service_constructs_envelope_and_persists_raw_output() {
     assert_eq!(envelope.parsed_payload["readiness"]["ready"], json!(true));
     assert_eq!(envelope.metadata.attempt_number, 1);
     assert_eq!(envelope.metadata.backend_used.family, BackendFamily::Claude);
-    assert_eq!(envelope.metadata.model_used.model_id, "claude-opus-4-6");
+    assert_eq!(envelope.metadata.model_used.model_id, "claude-opus-4-7");
     assert!(envelope.metadata.token_counts.total_tokens.is_some());
 }
 
@@ -503,7 +503,7 @@ async fn service_does_not_reuse_sessions_for_roles_that_disallow_it() {
         sessions: vec![SessionMetadata {
             role: BackendRole::Planner,
             backend_family: BackendFamily::Claude,
-            model_id: "claude-opus-4-6".to_owned(),
+            model_id: "claude-opus-4-7".to_owned(),
             session_id: "planner-session".to_owned(),
             created_at: timestamp,
             last_used_at: timestamp,

--- a/tests/unit/automation_runtime_test.rs
+++ b/tests/unit/automation_runtime_test.rs
@@ -3653,7 +3653,7 @@ async fn daemon_requirements_quick_without_defaults_uses_role_defaults() {
     let invocations = adapter.recorded_invocations();
     assert!(!invocations.is_empty());
     // Requirements stages only use Planner and Reviewer roles.
-    // Planner default: Claude / claude-opus-4-6
+    // Planner default: Claude / claude-opus-4-7
     // Reviewer default: Claude / sonnet-4.0
     for inv in &invocations {
         let expected = if inv.contract_label.contains("review") {

--- a/tests/unit/backend_diagnostics_test.rs
+++ b/tests/unit/backend_diagnostics_test.rs
@@ -748,7 +748,7 @@ fn show_effective_reports_final_review_panel_members() {
         .find(|r| r.role == "final_review_panel.reviewer[1]")
         .expect("second final-review reviewer row should exist");
     assert_eq!("claude", reviewer1.backend_family);
-    assert_eq!("claude-opus-4-6-max", reviewer1.model_id);
+    assert_eq!("claude-opus-4-7-max", reviewer1.model_id);
     assert_eq!("final_review.backends (default)", reviewer1.override_source);
     assert_eq!("final_review.backends (default)", reviewer1.model_source);
 
@@ -888,7 +888,7 @@ fn show_effective_final_reviewer_skips_optional_disabled_first_member() {
         .find(|r| r.role == "final_reviewer")
         .expect("compatibility final_reviewer row should exist");
     assert_eq!("claude", final_reviewer.backend_family);
-    assert_eq!("claude-opus-4-6-max", final_reviewer.model_id);
+    assert_eq!("claude-opus-4-7-max", final_reviewer.model_id);
     assert!(
         final_reviewer.resolution_error.is_none(),
         "optional disabled reviewer should be skipped for final_reviewer alias: {:?}",
@@ -938,7 +938,7 @@ fn probe_singular_final_reviewer_skips_optional_disabled_first_member() {
         .target
         .expect("singular role probe should return a target");
     assert_eq!("claude", target.backend_family);
-    assert_eq!("claude-opus-4-6-max", target.model_id);
+    assert_eq!("claude-opus-4-7-max", target.model_id);
 }
 
 // ── structured panel failure tests ───────────────────────────────────────────

--- a/tests/unit/backend_policy_test.rs
+++ b/tests/unit/backend_policy_test.rs
@@ -79,7 +79,7 @@ fn compiled_defaults_use_codex_high_implementer_and_cross_model_final_review_pan
         panel.reviewers[1].target.backend.family
     );
     assert_eq!(
-        "claude-opus-4-6-max",
+        "claude-opus-4-7-max",
         panel.reviewers[1].target.model.model_id
     );
     assert!(!panel.reviewers[1].required);
@@ -206,10 +206,10 @@ fn compiled_default_final_review_panel_honors_role_model_overrides() {
         BackendFamily::Claude,
         panel.reviewers[1].target.backend.family
     );
-    // Second reviewer has an inline model override (claude-opus-4-6-max) that
+    // Second reviewer has an inline model override (claude-opus-4-7-max) that
     // is not affected by role_models overrides.
     assert_eq!(
-        "claude-opus-4-6-max",
+        "claude-opus-4-7-max",
         panel.reviewers[1].target.model.model_id
     );
     // Third reviewer has an inline model override that is not affected by
@@ -250,10 +250,10 @@ fn explicit_default_model_overrides_compiled_codex_role_defaults() {
     // First reviewer has an inline model override (gpt-5.4-xhigh), unaffected
     // by default_model.
     assert_eq!("gpt-5.4-xhigh", panel.reviewers[0].target.model.model_id);
-    // Second reviewer has an inline model override (claude-opus-4-6-max),
+    // Second reviewer has an inline model override (claude-opus-4-7-max),
     // unaffected by default_model.
     assert_eq!(
-        "claude-opus-4-6-max",
+        "claude-opus-4-7-max",
         panel.reviewers[1].target.model.model_id
     );
     // Third reviewer has an inline model override, unaffected by default_model.

--- a/tests/unit/config_test.rs
+++ b/tests/unit/config_test.rs
@@ -52,7 +52,7 @@ fn effective_config_loads_compiled_defaults() {
     assert_eq!(
         vec![
             "codex/gpt-5.4-xhigh".to_owned(),
-            "?claude/claude-opus-4-6-max".to_owned(),
+            "?claude/claude-opus-4-7-max".to_owned(),
             "?codex/gpt-5.3-codex-spark-xhigh".to_owned(),
         ],
         match config

--- a/tests/unit/process_backend_test.rs
+++ b/tests/unit/process_backend_test.rs
@@ -623,7 +623,7 @@ async fn claude_suffix_model_adds_reasoning_effort_flag() {
 
     let (_dir, mut request) = request_fixture(BackendFamily::Claude);
     request.resolved_target =
-        ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-6-max");
+        ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-7-max");
 
     let envelope_file = request.working_dir.join("claude-envelope.json");
     write_claude_envelope(
@@ -642,11 +642,11 @@ async fn claude_suffix_model_adds_reasoning_effort_flag() {
     let args_text =
         fs::read_to_string(request.working_dir.join("claude-args.txt")).expect("read args");
     assert!(
-        args_text.contains("--model claude-opus-4-6"),
+        args_text.contains("--model claude-opus-4-7"),
         "should strip the effort suffix from --model: {args_text}"
     );
     assert!(
-        !args_text.contains("--model claude-opus-4-6-max"),
+        !args_text.contains("--model claude-opus-4-7-max"),
         "should not pass the suffixed model id through to the CLI: {args_text}"
     );
     assert!(
@@ -707,12 +707,12 @@ async fn claude_resume_suffix_model_adds_reasoning_effort_flag() {
 
     let (_dir, mut request) = request_fixture(BackendFamily::Claude);
     request.resolved_target =
-        ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-6-max");
+        ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-7-max");
     request.session_policy = SessionPolicy::ReuseIfAllowed;
     request.prior_session = Some(SessionMetadata {
         role: BackendRole::Planner,
         backend_family: BackendFamily::Claude,
-        model_id: "claude-opus-4-6-max".to_owned(),
+        model_id: "claude-opus-4-7-max".to_owned(),
         session_id: "ses-prior-123".to_owned(),
         created_at: Utc::now(),
         last_used_at: Utc::now(),
@@ -732,7 +732,7 @@ async fn claude_resume_suffix_model_adds_reasoning_effort_flag() {
     let args_text =
         fs::read_to_string(request.working_dir.join("claude-args.txt")).expect("read args");
     assert!(
-        args_text.contains("--model claude-opus-4-6"),
+        args_text.contains("--model claude-opus-4-7"),
         "should strip the effort suffix from --model on resume: {args_text}"
     );
     assert!(

--- a/tests/unit/workflow_engine_test.rs
+++ b/tests/unit/workflow_engine_test.rs
@@ -795,7 +795,7 @@ async fn primary_stage_artifacts_persist_agent_producer_metadata() {
                     requested_model_id: model_id,
                     ..
                 }
-            ) if backend_family == "claude" && model_id == "claude-opus-4-6"
+            ) if backend_family == "claude" && model_id == "claude-opus-4-7"
         ),
         "docs_plan primary artifact should persist agent producer metadata: {:?}",
         docs_plan_artifact.producer

--- a/tests/unit/workflow_panels_test.rs
+++ b/tests/unit/workflow_panels_test.rs
@@ -359,7 +359,7 @@ fn record_producer_round_trips() {
 fn record_producer_agent_with_adapter_reported_values_round_trips() {
     let with_different_actual = RecordProducer::Agent {
         requested_backend_family: "claude".to_string(),
-        requested_model_id: "claude-opus-4-6".to_string(),
+        requested_model_id: "claude-opus-4-7".to_string(),
         actual_backend_family: "openrouter".to_string(),
         actual_model_id: "openai/gpt-4.1".to_string(),
     };
@@ -369,7 +369,7 @@ fn record_producer_agent_with_adapter_reported_values_round_trips() {
     assert_eq!(json["actual_backend_family"], "openrouter");
     assert_eq!(json["actual_model_id"], "openai/gpt-4.1");
     assert_eq!(json["requested_backend_family"], "claude");
-    assert_eq!(json["requested_model_id"], "claude-opus-4-6");
+    assert_eq!(json["requested_model_id"], "claude-opus-4-7");
 
     // Round-trip
     let json_str = serde_json::to_string(&with_different_actual).unwrap();
@@ -381,9 +381,9 @@ fn record_producer_agent_with_adapter_reported_values_round_trips() {
 fn record_producer_agent_actual_fields_always_present_in_json() {
     let producer = RecordProducer::Agent {
         requested_backend_family: "claude".to_string(),
-        requested_model_id: "claude-opus-4-6".to_string(),
+        requested_model_id: "claude-opus-4-7".to_string(),
         actual_backend_family: "claude".to_string(),
-        actual_model_id: "claude-opus-4-6".to_string(),
+        actual_model_id: "claude-opus-4-7".to_string(),
     };
 
     let json = serde_json::to_value(&producer).unwrap();
@@ -392,7 +392,7 @@ fn record_producer_agent_actual_fields_always_present_in_json() {
         "actual_backend_family should always be present"
     );
     assert_eq!(
-        json["actual_model_id"], "claude-opus-4-6",
+        json["actual_model_id"], "claude-opus-4-7",
         "actual_model_id should always be present"
     );
 }
@@ -400,26 +400,26 @@ fn record_producer_agent_actual_fields_always_present_in_json() {
 #[test]
 fn record_producer_agent_deserializes_from_old_field_names() {
     // Simulates old JSON with the legacy field names
-    let old_json = r#"{"type":"agent","backend_family":"claude","model_id":"claude-opus-4-6"}"#;
+    let old_json = r#"{"type":"agent","backend_family":"claude","model_id":"claude-opus-4-7"}"#;
     let restored: RecordProducer = serde_json::from_str(old_json).unwrap();
     assert_eq!(
         restored,
         RecordProducer::Agent {
             requested_backend_family: "claude".to_string(),
-            requested_model_id: "claude-opus-4-6".to_string(),
+            requested_model_id: "claude-opus-4-7".to_string(),
             actual_backend_family: "claude".to_string(),
-            actual_model_id: "claude-opus-4-6".to_string(),
+            actual_model_id: "claude-opus-4-7".to_string(),
         }
     );
 
     // Old JSON with adapter_reported fields maps to actual fields
-    let old_json_with_adapter = r#"{"type":"agent","backend_family":"claude","model_id":"claude-opus-4-6","adapter_reported_backend_family":"openrouter","adapter_reported_model_id":"openai/gpt-4.1"}"#;
+    let old_json_with_adapter = r#"{"type":"agent","backend_family":"claude","model_id":"claude-opus-4-7","adapter_reported_backend_family":"openrouter","adapter_reported_model_id":"openai/gpt-4.1"}"#;
     let restored: RecordProducer = serde_json::from_str(old_json_with_adapter).unwrap();
     assert_eq!(
         restored,
         RecordProducer::Agent {
             requested_backend_family: "claude".to_string(),
-            requested_model_id: "claude-opus-4-6".to_string(),
+            requested_model_id: "claude-opus-4-7".to_string(),
             actual_backend_family: "openrouter".to_string(),
             actual_model_id: "openai/gpt-4.1".to_string(),
         }
@@ -534,13 +534,13 @@ fn record_producer_display_agent_matching() {
 fn record_producer_display_agent_mismatched() {
     let producer = RecordProducer::Agent {
         requested_backend_family: "claude".to_string(),
-        requested_model_id: "claude-opus-4-6".to_string(),
+        requested_model_id: "claude-opus-4-7".to_string(),
         actual_backend_family: "openrouter".to_string(),
         actual_model_id: "openai/gpt-4.1".to_string(),
     };
     assert_eq!(
         producer.to_string(),
-        "agent:openrouter/openai/gpt-4.1 (requested claude/claude-opus-4-6)"
+        "agent:openrouter/openai/gpt-4.1 (requested claude/claude-opus-4-7)"
     );
 }
 
@@ -548,11 +548,11 @@ fn record_producer_display_agent_mismatched() {
 fn record_producer_display_agent_legacy_empty_actual_falls_back_to_requested() {
     let producer = RecordProducer::Agent {
         requested_backend_family: "claude".to_string(),
-        requested_model_id: "claude-opus-4-6".to_string(),
+        requested_model_id: "claude-opus-4-7".to_string(),
         actual_backend_family: String::new(),
         actual_model_id: String::new(),
     };
-    assert_eq!(producer.to_string(), "agent:claude/claude-opus-4-6");
+    assert_eq!(producer.to_string(), "agent:claude/claude-opus-4-7");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Update all `claude-opus-4-6` model ID references to `claude-opus-4-7` across 13 files
- Update all `claude-opus-4-6-max` references to `claude-opus-4-7-max`
- Covers source code defaults, config defaults, test fixtures, and conformance scenarios

## Test plan
- [x] All 2047 tests pass
- [x] cargo clippy -- -D warnings clean
- [x] cargo fmt --check clean