### PR TITLE
flake: separate nix run package from checked build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,8 +60,25 @@
           '';
         });
 
+        staticRunPackage = pkgs.pkgsStatic.rustPlatform.buildRustPackage (commonArgs // {
+          doCheck = false;
+          postInstall = ''
+            echo "verifying static linkage..."
+            file_output="$(${pkgs.file}/bin/file "$out/bin/ralph-burning")"
+            echo "$file_output"
+            if ! echo "$file_output" | grep -Eq "statically linked|static-pie linked"; then
+              echo "FAIL: binary is NOT statically linked"
+              exit 1
+            fi
+          '';
+        });
+
         dynamicPackage = pkgs.rustPlatform.buildRustPackage (commonArgs // {
           cargoTestFlags = [ "--features" "test-stub" ];
+        });
+
+        dynamicRunPackage = pkgs.rustPlatform.buildRustPackage (commonArgs // {
+          doCheck = false;
         });
       in
       {
@@ -69,13 +86,16 @@
           {
             default = if isLinux then staticPackage else dynamicPackage;
             dynamic = dynamicPackage;
+            run = if isLinux then staticRunPackage else dynamicRunPackage;
+            dynamic-run = dynamicRunPackage;
           }
           // pkgs.lib.optionalAttrs isLinux {
             static = staticPackage;
+            static-run = staticRunPackage;
           };
 
         apps.default = flake-utils.lib.mkApp {
-          drv = self.packages.${system}.default;
+          drv = self.packages.${system}.run;
         };
 
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
## Summary
- add dedicated run packages with `doCheck = false` for static and dynamic builds
- keep `packages.default` on the checked build used by `nix build`
- point `apps.default` at the run package so `nix run` compiles and launches the binary without running the full check suite

## Verification
- `nix run /home/user/ralph-burning -- --help`
- repository pre-push checks passed during `git push`