### PR TITLE
[codex] Fix bead-aware dogfooding regressions

### DIFF
--- a/src/adapters/br_process.rs
+++ b/src/adapters/br_process.rs
@@ -354,6 +354,11 @@ impl BrCommand {
         Self::new("show").arg(id).json()
     }
 
+    /// `br show <id> --json --no-db`
+    pub fn show_no_db(id: impl Into<String>) -> Self {
+        Self::new("show").arg(id).json().flag("no-db")
+    }
+
     /// `br ready --json`
     pub fn ready() -> Self {
         Self::new("ready").json()
@@ -1385,6 +1390,34 @@ impl<R: ProcessRunner> BrMutationAdapter<R> {
             "updated bead status"
         );
         Ok(output)
+    }
+
+    /// Recreate this adapter's pending status-update journal after an
+    /// externally observed local status change proved the subprocess mutated
+    /// bead state before exiting non-zero.
+    pub async fn restore_pending_status_update(
+        &self,
+        id: &str,
+        status: &str,
+    ) -> Result<(), BrError> {
+        let _operation_guard = self.operation_lock.lock().await;
+        let _repo_guard = self.acquire_repo_operation_lock()?;
+        let record = PendingMutationRecord::new(
+            self.adapter_id.clone(),
+            "update_bead_status",
+            Some(id),
+            Some(status),
+        );
+        self.persist_pending_mutation_record(&record)?;
+        self.has_unsync_mutations.store(true, Ordering::Release);
+        tracing::warn!(
+            operation = "update_bead_status",
+            bead_id = id,
+            status = status,
+            outcome = "recovered_pending_record",
+            "restored br pending mutation record after a subprocess reported failure despite an observed local status change"
+        );
+        Ok(())
     }
 
     /// Close a bead with a reason.

--- a/src/adapters/fs.rs
+++ b/src/adapters/fs.rs
@@ -1243,8 +1243,12 @@ impl FileSystem {
         Ok(())
     }
 
+    pub(crate) fn seed_live_workspace(base_dir: &Path) -> AppResult<()> {
+        Self::ensure_live_workspace_seeded(base_dir)
+    }
+
     fn ensure_live_project_root(base_dir: &Path, project_id: &ProjectId) -> AppResult<PathBuf> {
-        Self::ensure_live_workspace_seeded(base_dir)?;
+        Self::seed_live_workspace(base_dir)?;
         let live_root = Self::live_project_root(base_dir, project_id);
         if live_root.join(PROJECT_CONFIG_FILE).is_file() {
             return Ok(live_root);
@@ -1564,11 +1568,7 @@ impl ProjectStorePort for FsProjectStore {
                 continue;
             }
             if !project_root.join(PROJECT_CONFIG_FILE).is_file() {
-                return Err(AppError::CorruptRecord {
-                    file: format!("projects/{id}/project.toml"),
-                    details: "project directory exists but canonical project.toml is missing"
-                        .to_owned(),
-                });
+                continue;
             }
             ids.push(pid);
         }

--- a/src/cli/milestone.rs
+++ b/src/cli/milestone.rs
@@ -615,8 +615,19 @@ async fn handle_next(milestone_id: Option<String>, json: bool) -> AppResult<()> 
     validate_workspace(&current_dir)?;
 
     let store = FsMilestoneStore;
+    let snapshot_store = FsMilestoneSnapshotStore;
+    let plan_store = FsMilestonePlanStore;
+    let requirements_store = FsRequirementsStore;
     let milestone_id = resolve_requested_milestone(&store, &current_dir, milestone_id)?;
     workspace_governance::set_active_milestone(&current_dir, &milestone_id)?;
+    ensure_execution_plan_available(
+        &snapshot_store,
+        &plan_store,
+        &requirements_store,
+        &current_dir,
+        &milestone_id,
+        "next",
+    )?;
 
     let outcome = inspect_next_milestone_action(&current_dir, &milestone_id).await?;
     let failure =
@@ -639,8 +650,19 @@ async fn handle_run(milestone_id: Option<String>, json: bool) -> AppResult<()> {
     validate_workspace(&current_dir)?;
 
     let store = FsMilestoneStore;
+    let snapshot_store = FsMilestoneSnapshotStore;
+    let plan_store = FsMilestonePlanStore;
+    let requirements_store = FsRequirementsStore;
     let milestone_id = resolve_requested_milestone(&store, &current_dir, milestone_id)?;
     workspace_governance::set_active_milestone(&current_dir, &milestone_id)?;
+    ensure_execution_plan_available(
+        &snapshot_store,
+        &plan_store,
+        &requirements_store,
+        &current_dir,
+        &milestone_id,
+        "run",
+    )?;
 
     let outcome = execute_milestone_run(&current_dir, &milestone_id).await?;
     let failure = milestone_command_failure(&milestone_id, "run", outcome.status, &outcome.message);
@@ -1422,10 +1444,30 @@ fn load_bead_detail_from_br(
     milestone_id: &MilestoneId,
     bead_id: &str,
 ) -> AppResult<Option<BeadDetail>> {
-    let output = std::process::Command::new("br")
+    let primary = std::process::Command::new("br")
         .args(["show", bead_id, "--json"])
         .current_dir(base_dir)
         .output()?;
+    if let Some(result) = parse_bead_detail_from_br_output(&primary, milestone_id, bead_id)? {
+        return Ok(Some(result));
+    }
+
+    if bead_id.contains('.') {
+        return Ok(None);
+    }
+
+    let no_db = std::process::Command::new("br")
+        .args(["show", bead_id, "--json", "--no-db"])
+        .current_dir(base_dir)
+        .output()?;
+    parse_bead_detail_from_br_output(&no_db, milestone_id, bead_id)
+}
+
+fn parse_bead_detail_from_br_output(
+    output: &std::process::Output,
+    milestone_id: &MilestoneId,
+    bead_id: &str,
+) -> AppResult<Option<BeadDetail>> {
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
@@ -1452,21 +1494,9 @@ fn load_bead_detail_from_br(
     match response {
         BrShowResponse::Single(detail) => {
             if bead_id.contains('.') {
-                if detail.id != bead_id {
-                    return Err(AppError::Io(std::io::Error::other(format!(
-                        "br show {bead_id} --json returned bead '{}'",
-                        detail.id
-                    ))));
-                }
-                Ok(Some(detail))
-            } else if milestone_bead_refs_match(milestone_id, &detail.id, bead_id) {
-                Ok(Some(detail))
-            } else {
-                Err(AppError::Io(std::io::Error::other(format!(
-                    "br show {bead_id} --json returned bead '{}'",
-                    detail.id
-                ))))
+                return Ok((detail.id == bead_id).then_some(detail));
             }
+            Ok(milestone_bead_refs_match(milestone_id, &detail.id, bead_id).then_some(detail))
         }
         BrShowResponse::Many(details) => {
             let mut matches = details.into_iter().filter(|detail| {
@@ -1476,15 +1506,13 @@ fn load_bead_detail_from_br(
                     milestone_bead_refs_match(milestone_id, &detail.id, bead_id)
                 }
             });
-            let Some(detail) = matches.next() else {
-                return Ok(None);
-            };
+            let detail = matches.next();
             if matches.next().is_some() {
                 return Err(AppError::Io(std::io::Error::other(format!(
                     "br show {bead_id} --json returned multiple matching beads"
                 ))));
             }
-            Ok(Some(detail))
+            Ok(detail)
         }
     }
 }
@@ -1686,6 +1714,46 @@ fn load_milestone_detail(
         created_at: record.created_at,
         updated_at: inspection.snapshot.updated_at,
         has_plan,
+    })
+}
+
+fn ensure_execution_plan_available(
+    snapshot_store: &impl MilestoneSnapshotPort,
+    plan_store: &impl MilestonePlanPort,
+    requirements_store: &impl RequirementsStorePort,
+    base_dir: &std::path::Path,
+    milestone_id: &MilestoneId,
+    action: &str,
+) -> AppResult<()> {
+    let inspection = load_inspection_state(
+        snapshot_store,
+        plan_store,
+        requirements_store,
+        base_dir,
+        milestone_id,
+    )
+    .map_err(|error| map_action_error(milestone_id, action, error))?;
+
+    if inspection.plan.is_some() {
+        return Ok(());
+    }
+
+    let details = if inspection.display_status == MilestoneStatus::Planning.to_string() {
+        format!(
+            "milestone is still planning and has no plan.json yet; run `ralph-burning milestone plan {}` and retry",
+            milestone_id
+        )
+    } else {
+        format!(
+            "milestone has no live plan.json; run `ralph-burning milestone plan {}` and retry",
+            milestone_id
+        )
+    };
+
+    Err(AppError::MilestoneOperationFailed {
+        milestone_id: milestone_id.to_string(),
+        action: action.to_owned(),
+        details,
     })
 }
 
@@ -1939,6 +2007,17 @@ fn map_inspection_error(milestone_id: &MilestoneId, error: AppError) -> AppError
         other => AppError::MilestoneOperationFailed {
             milestone_id: milestone_id.to_string(),
             action: "inspection".to_owned(),
+            details: other.to_string(),
+        },
+    }
+}
+
+fn map_action_error(milestone_id: &MilestoneId, action: &str, error: AppError) -> AppError {
+    match error {
+        AppError::MilestoneNotFound { .. } | AppError::MilestoneOperationFailed { .. } => error,
+        other => AppError::MilestoneOperationFailed {
+            milestone_id: milestone_id.to_string(),
+            action: action.to_owned(),
             details: other.to_string(),
         },
     }

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -1037,11 +1037,7 @@ async fn claim_bead_in_br(base_dir: &Path, bead_id: &str, claim_owner: &str) -> 
         );
     }
     if recovered_flush.includes_owned_update_status(&claim_owner_token, bead_id, "in_progress") {
-        match br
-            .inner()
-            .exec_json::<BeadDetail>(&BrCommand::show(bead_id.to_owned()))
-            .await
-        {
+        match load_exact_bead_detail_for_claim(&br, bead_id).await {
             Ok(detail) if detail.status == BeadStatus::InProgress => {
                 ensure_beads_claim_post_flush_health(base_dir, bead_id)?;
                 tracing::info!(
@@ -1071,14 +1067,16 @@ async fn claim_bead_in_br(base_dir: &Path, bead_id: &str, claim_owner: &str) -> 
     }
 
     ensure_beads_claim_health(base_dir, bead_id)?;
-    br.update_bead_status(bead_id, "in_progress")
-        .await
-        .map_err(|update_error| {
-            AppError::Io(std::io::Error::other(format!(
+    if let Err(update_error) = br.update_bead_status(bead_id, "in_progress").await {
+        if !recover_claim_after_false_missing_update(&br, bead_id, claim_owner, &update_error)
+            .await?
+        {
+            return Err(AppError::Io(std::io::Error::other(format!(
                 "failed to claim bead '{bead_id}' via br update --status=in_progress: \
                  {update_error}"
-            )))
-        })?;
+            ))));
+        }
+    }
     match br.sync_own_dirty_if_beads_healthy(base_dir).await {
         Ok(_) => {}
         Err(SyncIfDirtyHealthError::UnsafeBeadsState { details }) => {
@@ -1098,6 +1096,107 @@ async fn claim_bead_in_br(base_dir: &Path, bead_id: &str, claim_owner: &str) -> 
         }
     }
     Ok(())
+}
+
+fn br_update_error_indicates_missing_bead(error: &BrError) -> bool {
+    match error {
+        BrError::BrExitError { stderr, stdout, .. } => {
+            br_show_output_indicates_missing(stderr, stdout)
+        }
+        _ => false,
+    }
+}
+
+async fn recover_claim_after_false_missing_update(
+    br: &BrMutationAdapter,
+    bead_id: &str,
+    claim_owner: &str,
+    update_error: &BrError,
+) -> AppResult<bool> {
+    if !br_update_error_indicates_missing_bead(update_error) {
+        return Ok(false);
+    }
+
+    match load_exact_bead_detail_for_claim(br, bead_id).await {
+        Ok(detail) if detail.status == BeadStatus::InProgress => {
+            br.restore_pending_status_update(bead_id, "in_progress")
+                .await
+                .map_err(|restore_error| {
+                    AppError::Io(std::io::Error::other(format!(
+                        "bead '{bead_id}' was locally claimed despite a false `br update` \
+                         failure, but Ralph could not restore its pending mutation journal: \
+                         {restore_error}"
+                    )))
+                })?;
+            tracing::warn!(
+                bead_id = bead_id,
+                claim_owner = claim_owner,
+                %update_error,
+                "br update reported a missing bead even though br show confirmed in_progress; restored the pending mutation record and continuing with guarded sync"
+            );
+            Ok(true)
+        }
+        Ok(detail) => {
+            tracing::warn!(
+                bead_id = bead_id,
+                claim_owner = claim_owner,
+                current_status = %detail.status,
+                %update_error,
+                "br update reported a missing bead but br show did not confirm an in_progress claim"
+            );
+            Ok(false)
+        }
+        Err(show_error) => {
+            tracing::warn!(
+                bead_id = bead_id,
+                claim_owner = claim_owner,
+                %update_error,
+                %show_error,
+                "br update reported a missing bead and Ralph could not verify the bead state afterward"
+            );
+            Ok(false)
+        }
+    }
+}
+
+async fn load_exact_bead_detail_for_claim(
+    br: &BrMutationAdapter,
+    bead_id: &str,
+) -> Result<BeadDetail, BrError> {
+    let detail = br
+        .inner()
+        .exec_json::<BeadDetail>(&BrCommand::show(bead_id.to_owned()))
+        .await?;
+    if detail.id == bead_id {
+        return Ok(detail);
+    }
+    if bead_id.contains('.') {
+        return Err(BrError::BrParseError {
+            details: format!(
+                "br show returned bead '{}' while claiming exact bead '{bead_id}'",
+                detail.id
+            ),
+            raw_output: String::new(),
+            command: format!("br show {bead_id} --json"),
+        });
+    }
+
+    let detail = br
+        .inner()
+        .exec_json::<BeadDetail>(&BrCommand::show_no_db(bead_id.to_owned()))
+        .await?;
+    if detail.id == bead_id {
+        return Ok(detail);
+    }
+
+    Err(BrError::BrParseError {
+        details: format!(
+            "br show --no-db returned bead '{}' while claiming exact bead '{bead_id}'",
+            detail.id
+        ),
+        raw_output: String::new(),
+        command: format!("br show {bead_id} --json --no-db"),
+    })
 }
 
 fn claim_owner_token(claim_owner: &str, bead_id: &str) -> String {
@@ -1136,46 +1235,60 @@ async fn load_bead_detail(
     milestone_id: &MilestoneId,
     bead_id: &str,
 ) -> AppResult<BeadDetail> {
-    let response: BrShowResponse = BrAdapter::new()
-        .with_working_dir(base_dir.to_path_buf())
+    let br = BrAdapter::new().with_working_dir(base_dir.to_path_buf());
+    let response: BrShowResponse = br
         .exec_json(&BrCommand::show(bead_id))
         .await
-        .map_err(|error| match error {
-            BrError::BrExitError { stderr, stdout, .. }
-                if br_show_output_indicates_missing(&stderr, &stdout) =>
-            {
-                AppError::Io(std::io::Error::other(format!(
-                    "failed to load bead '{bead_id}': bead not found"
-                )))
-            }
-            BrError::BrExitError { stderr, .. } => AppError::Io(std::io::Error::other(format!(
-                "failed to load bead '{bead_id}': {stderr}"
-            ))),
-            other => AppError::Io(std::io::Error::other(format!(
-                "failed to load bead '{bead_id}': {other}"
-            ))),
-        })?;
+        .map_err(|error| map_br_show_error(bead_id, error))?;
 
+    if let Some(bead) = select_matching_bead_from_show_response(milestone_id, bead_id, response)? {
+        return Ok(bead);
+    }
+
+    if !bead_id.contains('.') {
+        let response: BrShowResponse = br
+            .exec_json(&BrCommand::show_no_db(bead_id))
+            .await
+            .map_err(|error| map_br_show_error(bead_id, error))?;
+        if let Some(bead) =
+            select_matching_bead_from_show_response(milestone_id, bead_id, response)?
+        {
+            return Ok(bead);
+        }
+    }
+
+    Err(unmatched_br_show_error(milestone_id, bead_id))
+}
+
+fn map_br_show_error(bead_id: &str, error: BrError) -> AppError {
+    match error {
+        BrError::BrExitError { stderr, stdout, .. }
+            if br_show_output_indicates_missing(&stderr, &stdout) =>
+        {
+            AppError::Io(std::io::Error::other(format!(
+                "failed to load bead '{bead_id}': bead not found"
+            )))
+        }
+        BrError::BrExitError { stderr, .. } => AppError::Io(std::io::Error::other(format!(
+            "failed to load bead '{bead_id}': {stderr}"
+        ))),
+        other => AppError::Io(std::io::Error::other(format!(
+            "failed to load bead '{bead_id}': {other}"
+        ))),
+    }
+}
+
+fn select_matching_bead_from_show_response(
+    milestone_id: &MilestoneId,
+    bead_id: &str,
+    response: BrShowResponse,
+) -> AppResult<Option<BeadDetail>> {
     match response {
         BrShowResponse::Single(bead) => {
             if bead_id.contains('.') {
-                if bead.id != bead_id {
-                    return Err(AppError::Io(std::io::Error::other(format!(
-                        "failed to load bead '{bead_id}': br show returned bead '{}'",
-                        bead.id
-                    ))));
-                }
-                return Ok(bead);
+                return Ok((bead.id == bead_id).then_some(bead));
             }
-
-            if milestone_bead_refs_match(milestone_id, &bead.id, bead_id) {
-                return Ok(bead);
-            }
-
-            Err(AppError::Io(std::io::Error::other(format!(
-                "failed to load bead '{bead_id}': br show returned bead '{}'",
-                bead.id
-            ))))
+            Ok(milestone_bead_refs_match(milestone_id, &bead.id, bead_id).then_some(bead))
         }
         BrShowResponse::Many(beads) => {
             let mut matches = beads.into_iter().filter(|bead| {
@@ -1185,19 +1298,7 @@ async fn load_bead_detail(
                     milestone_bead_refs_match(milestone_id, &bead.id, bead_id)
                 }
             });
-            let bead = matches.next().ok_or_else(|| {
-                let detail = if bead_id.contains('.') {
-                    "br show returned no matching bead".to_owned()
-                } else {
-                    format!(
-                        "br show returned no matching bead in milestone '{}'",
-                        milestone_id
-                    )
-                };
-                AppError::Io(std::io::Error::other(format!(
-                    "failed to load bead '{bead_id}': {detail}"
-                )))
-            })?;
+            let bead = matches.next();
             if matches.next().is_some() {
                 return Err(AppError::Io(std::io::Error::other(format!(
                     "failed to load bead '{bead_id}': br show returned multiple matching beads"
@@ -1206,6 +1307,20 @@ async fn load_bead_detail(
             Ok(bead)
         }
     }
+}
+
+fn unmatched_br_show_error(milestone_id: &MilestoneId, bead_id: &str) -> AppError {
+    let detail = if bead_id.contains('.') {
+        "br show returned no matching bead".to_owned()
+    } else {
+        format!(
+            "br show returned no matching bead in milestone '{}'",
+            milestone_id
+        )
+    };
+    AppError::Io(std::io::Error::other(format!(
+        "failed to load bead '{bead_id}': {detail}"
+    )))
 }
 
 async fn load_bead_summaries(base_dir: &Path) -> AppResult<BTreeMap<String, BeadSummary>> {
@@ -1325,7 +1440,7 @@ fn ensure_bead_belongs_to_milestone(
     bead: &BeadDetail,
 ) -> AppResult<()> {
     let expected_prefix = format!("{}.", milestone_id.as_str());
-    if bead.id.starts_with(&expected_prefix) {
+    if bead.id.starts_with(&expected_prefix) || !bead.id.contains('.') {
         return Ok(());
     }
 
@@ -3812,6 +3927,31 @@ mod tests {
     }
 
     #[test]
+    fn ensure_bead_belongs_to_milestone_accepts_unqualified_explicit_id() {
+        let milestone_id = MilestoneId::new("ms-alpha").expect("milestone id");
+        let mut bead = sample_bead();
+        bead.id = "ralph-burning-evi".to_owned();
+
+        ensure_bead_belongs_to_milestone(&milestone_id, &bead)
+            .expect("unqualified explicit bead id should pass");
+    }
+
+    #[test]
+    fn ensure_bead_belongs_to_milestone_rejects_foreign_qualified_id() {
+        let milestone_id = MilestoneId::new("ms-alpha").expect("milestone id");
+        let mut bead = sample_bead();
+        bead.id = "other-ms.bead-2".to_owned();
+
+        let error = ensure_bead_belongs_to_milestone(&milestone_id, &bead)
+            .expect_err("foreign qualified bead id should fail");
+
+        assert!(matches!(error, AppError::InvalidConfigValue { .. }));
+        assert!(error
+            .to_string()
+            .contains("expected bead id to belong to milestone 'ms-alpha'"));
+    }
+
+    #[test]
     fn validate_milestone_plan_snapshot_rejects_stale_hash() {
         let milestone_id = MilestoneId::new("ms-alpha").expect("milestone id");
         let error =
@@ -3880,6 +4020,74 @@ mod tests {
             assert!(error
                 .to_string()
                 .contains(&format!("bead is already {status}")));
+        }
+    }
+
+    #[cfg(unix)]
+    mod load_bead_detail_tests {
+        use std::os::unix::fs::PermissionsExt;
+
+        use super::*;
+        use crate::test_support::env::{lock_path_mutex, PathGuard};
+
+        fn install_fake_br_show_retry_no_db(
+            base_dir: &std::path::Path,
+            bead_id: &str,
+            foreign_id: &str,
+        ) {
+            let fake_bin = base_dir.join("fake-bin");
+            std::fs::create_dir_all(&fake_bin).expect("create fake bin dir");
+            let script = format!(
+                r#"#!/bin/sh
+case "$1" in
+  --version)
+    echo "br test stub"
+    exit 0
+    ;;
+  show)
+    for arg in "$@"; do
+      if [ "$arg" = "--no-db" ]; then
+        cat <<'BEAD_JSON'
+{{"id":"{bead_id}","title":"Expected explicit bead","status":"in_progress","priority":1,"bead_type":"task","labels":[],"dependencies":[],"dependents":[],"acceptance_criteria":[]}}
+BEAD_JSON
+        exit 0
+      fi
+    done
+    cat <<'BEAD_JSON'
+{{"id":"{foreign_id}","title":"Foreign bead","status":"closed","priority":1,"bead_type":"task","labels":[],"dependencies":[],"dependents":[],"acceptance_criteria":[]}}
+BEAD_JSON
+    exit 0
+    ;;
+  *)
+    echo "unexpected: $*" >&2
+    exit 1
+    ;;
+esac
+"#
+            );
+            let br_path = fake_bin.join("br");
+            std::fs::write(&br_path, script).expect("write fake br");
+            std::fs::set_permissions(&br_path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod fake br");
+        }
+
+        #[tokio::test]
+        async fn load_bead_detail_retries_no_db_for_unqualified_explicit_ids(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let _path_lock = lock_path_mutex();
+            let temp_dir = tempfile::tempdir()?;
+            let base_dir = temp_dir.path();
+
+            install_fake_br_show_retry_no_db(base_dir, "ralph-burning-evi", "ralph-burning-pfr");
+            let _path_guard = PathGuard::prepend(&base_dir.join("fake-bin"));
+
+            let milestone_id = MilestoneId::new("ms-explicit")?;
+            let bead = super::super::load_bead_detail(base_dir, &milestone_id, "ralph-burning-evi")
+                .await?;
+
+            assert_eq!(bead.id, "ralph-burning-evi");
+            assert_eq!(bead.status, BeadStatus::InProgress);
+            Ok(())
         }
     }
 
@@ -3971,6 +4179,68 @@ case "$1" in
     ;;
 esac
 "#;
+            let br_path = fake_bin.join("br");
+            std::fs::write(&br_path, script).expect("write fake br");
+            std::fs::set_permissions(&br_path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod fake br");
+        }
+
+        /// Install a fake `br` where `update` applies the local status change
+        /// but still exits non-zero with a false "issue not found" error.
+        fn install_fake_br_claim_false_missing_after_local_update(
+            base_dir: &std::path::Path,
+            bead_id: &str,
+        ) {
+            write_beads_export(base_dir, "{\"id\":\"seed-bead\"}\n");
+            let fake_bin = base_dir.join("fake-bin");
+            std::fs::create_dir_all(&fake_bin).expect("create fake bin dir");
+            let script = format!(
+                r#"#!/bin/sh
+set -eu
+
+case "$1" in
+  --version)
+    echo "br test stub"
+    exit 0
+    ;;
+  update)
+    count=0
+    if [ -f .beads/update-count ]; then
+      count=$(cat .beads/update-count)
+    fi
+    count=$((count + 1))
+    echo "$count" > .beads/update-count
+    echo "in_progress" > .beads/{bead_id}.status
+    echo "Error: Issue not found: {bead_id}" >&2
+    exit 3
+    ;;
+  sync)
+    count=0
+    if [ -f .beads/sync-count ]; then
+      count=$(cat .beads/sync-count)
+    fi
+    count=$((count + 1))
+    echo "$count" > .beads/sync-count
+    echo "Synced"
+    exit 0
+    ;;
+  show)
+    status="open"
+    if [ -f .beads/{bead_id}.status ]; then
+      status=$(cat .beads/{bead_id}.status)
+    fi
+    cat <<BEAD_JSON
+{{"id":"{bead_id}","title":"Test bead","status":"$status","priority":1,"bead_type":"task","labels":[],"dependencies":[],"dependents":[],"acceptance_criteria":[]}}
+BEAD_JSON
+    exit 0
+    ;;
+  *)
+    echo "unexpected: $*" >&2
+    exit 1
+    ;;
+esac
+"#
+            );
             let br_path = fake_bin.join("br");
             std::fs::write(&br_path, script).expect("write fake br");
             std::fs::set_permissions(&br_path, std::fs::Permissions::from_mode(0o755))
@@ -4397,6 +4667,33 @@ esac
             assert!(
                 error.contains("failed to claim bead 'bead-1'"),
                 "error should mention the bead id: {error}"
+            );
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn claim_bead_in_br_recovers_when_update_false_reports_missing_after_local_claim(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let _path_lock = lock_path_mutex();
+            let temp_dir = tempfile::tempdir()?;
+            let base_dir = temp_dir.path();
+
+            install_fake_br_claim_false_missing_after_local_update(base_dir, "bead-1");
+            let _path_guard = PathGuard::prepend(&base_dir.join("fake-bin"));
+
+            super::super::claim_bead_in_br(base_dir, "bead-1", claim_owner()).await?;
+
+            let update_count = std::fs::read_to_string(base_dir.join(".beads/update-count"))?;
+            assert_eq!(
+                update_count.trim(),
+                "1",
+                "the false-negative update path should not retry the mutation"
+            );
+            let sync_count = std::fs::read_to_string(base_dir.join(".beads/sync-count"))?;
+            assert_eq!(
+                sync_count.trim(),
+                "1",
+                "the recovered pending journal should still drive a final guarded sync"
             );
             Ok(())
         }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -26,7 +26,7 @@ use rustix::process::{
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::adapters::br_models::{BeadDetail, BeadStatus, DependencyKind, ReadyBead};
+use crate::adapters::br_models::{BeadDetail, BeadStatus, BeadSummary, DependencyKind, ReadyBead};
 use crate::adapters::br_process::{BrAdapter, BrCommand, BrError, ProcessRunner};
 use crate::adapters::bv_process::{BvAdapter, BvCommand, BvProcessRunner, NextBeadResponse};
 use crate::adapters::fs::{
@@ -274,6 +274,35 @@ impl ProjectMilestoneControllerRuntime<'_> {
     fn planned_bead_membership_refs(&self) -> AppResult<HashSet<String>> {
         load_planned_bead_membership_refs(self.base_dir, self.milestone_id)
     }
+
+    fn exact_bead_status_from_list(
+        &self,
+        bead_id: &str,
+    ) -> AppResult<Option<ControllerBeadStatus>> {
+        let response: BrListResponse = self.query_br_json(
+            &["list", "--all", "--deferred", "--limit=0", "--json"],
+            "milestone controller resume",
+        )?;
+        let issues = match response {
+            BrListResponse::Envelope { issues } => issues,
+            BrListResponse::Many(issues) => issues,
+        };
+        let mut matches = issues
+            .into_iter()
+            .filter(|issue| milestone_bead_refs_match(self.milestone_id, &issue.id, bead_id));
+        let issue = matches.next();
+        if matches.next().is_some() {
+            return Err(AppError::ResumeFailed {
+                reason: format!(
+                    "milestone controller resume found multiple exact-list matches for '{bead_id}'"
+                ),
+            });
+        }
+        Ok(issue.map(|issue| match issue.status {
+            BeadStatus::Closed => ControllerBeadStatus::Closed,
+            _ => ControllerBeadStatus::Open,
+        }))
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -288,6 +317,13 @@ struct BvMessageOnlyResponse {
 enum BrShowResponse {
     Single(BeadDetail),
     Many(Vec<BeadDetail>),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum BrListResponse {
+    Envelope { issues: Vec<BeadSummary> },
+    Many(Vec<BeadSummary>),
 }
 
 #[derive(Debug, Clone)]
@@ -333,6 +369,15 @@ fn summarize_bead_ids(ids: &[String]) -> String {
     } else {
         format!("{} (and {} more)", shown.join(", "), ids.len() - MAX_IDS)
     }
+}
+
+fn preferred_ready_milestone_bead(ready_beads: &[ReadyBead]) -> Option<&ReadyBead> {
+    ready_beads.iter().min_by(|left, right| {
+        left.priority
+            .value()
+            .cmp(&right.priority.value())
+            .then_with(|| left.id.cmp(&right.id))
+    })
 }
 
 fn br_show_error_is_missing(error: &BrError) -> bool {
@@ -621,6 +666,20 @@ async fn complete_next_milestone_bead_selection<R: ProcessRunner>(
                 milestone_id,
                 &recommendation.id,
             ) {
+                if let Some(fallback_bead) = preferred_ready_milestone_bead(&ready_beads) {
+                    return transition_controller_for_selection_outcome(
+                        base_dir,
+                        milestone_id,
+                        MilestoneControllerState::Claimed,
+                        Some(&fallback_bead.id),
+                        format!(
+                            "bv recommended bead '{}', but it is not part of milestone '{}'; claiming ready milestone bead '{}' instead",
+                            recommendation.id, milestone_id, fallback_bead.id
+                        ),
+                        now,
+                    );
+                }
+
                 let ready_ids = ready_beads
                     .iter()
                     .map(|bead| bead.id.clone())
@@ -667,6 +726,20 @@ async fn complete_next_milestone_bead_selection<R: ProcessRunner>(
             )
         }
         NextRecommendationOutcome::NoRecommendation => {
+            if let Some(fallback_bead) = preferred_ready_milestone_bead(&ready_beads) {
+                return transition_controller_for_selection_outcome(
+                    base_dir,
+                    milestone_id,
+                    MilestoneControllerState::Claimed,
+                    Some(&fallback_bead.id),
+                    format!(
+                        "bv reported no actionable bead; claiming ready milestone bead '{}' instead",
+                        fallback_bead.id
+                    ),
+                    now,
+                );
+            }
+
             let ready_ids = ready_beads
                 .iter()
                 .map(|bead| bead.id.clone())
@@ -949,10 +1022,23 @@ impl MilestoneControllerResumePort for ProjectMilestoneControllerRuntime<'_> {
                     ),
                 }
             })?;
-        let detail = match response {
-            BrShowResponse::Single(detail) => {
-                milestone_bead_refs_match(self.milestone_id, &detail.id, bead_id).then_some(detail)
+        match response {
+            BrShowResponse::Single(detail)
+                if milestone_bead_refs_match(self.milestone_id, &detail.id, bead_id) =>
+            {
+                Ok(match detail.status {
+                    BeadStatus::Closed => ControllerBeadStatus::Closed,
+                    _ => ControllerBeadStatus::Open,
+                })
             }
+            BrShowResponse::Single(detail) => self
+                .exact_bead_status_from_list(bead_id)?
+                .ok_or_else(|| AppError::ResumeFailed {
+                    reason: format!(
+                        "milestone controller resume asked for bead '{bead_id}' but br show returned '{}' and the exact list lookup found no match",
+                        detail.id
+                    ),
+                }),
             BrShowResponse::Many(details) => {
                 let mut matches = details.into_iter().filter(|detail| {
                     milestone_bead_refs_match(self.milestone_id, &detail.id, bead_id)
@@ -965,16 +1051,21 @@ impl MilestoneControllerResumePort for ProjectMilestoneControllerRuntime<'_> {
                         ),
                     });
                 }
-                detail
+                match detail {
+                    Some(detail) => Ok(match detail.status {
+                        BeadStatus::Closed => ControllerBeadStatus::Closed,
+                        _ => ControllerBeadStatus::Open,
+                    }),
+                    None => self
+                        .exact_bead_status_from_list(bead_id)?
+                        .ok_or_else(|| AppError::ResumeFailed {
+                            reason: format!(
+                                "milestone controller resume asked for bead '{bead_id}' but br show returned no matching bead and the exact list lookup found no match"
+                            ),
+                        }),
+                }
             }
-        };
-        let Some(detail) = detail else {
-            return Ok(ControllerBeadStatus::Missing);
-        };
-        Ok(match detail.status {
-            BeadStatus::Closed => ControllerBeadStatus::Closed,
-            _ => ControllerBeadStatus::Open,
-        })
+        }
     }
 
     fn task_status(&self, task_id: &str) -> AppResult<ControllerTaskStatus> {
@@ -3598,8 +3689,10 @@ pub(crate) async fn execute_start(
     }
 
     let amendment_queue = FsAmendmentQueueStore;
-    let retry_policy = RetryPolicy::default_policy()
-        .with_max_remediation_cycles(effective_config.run_policy().max_review_iterations);
+    let retry_policy = apply_test_retry_policy_overrides(
+        RetryPolicy::default_policy()
+            .with_max_remediation_cycles(effective_config.run_policy().max_review_iterations),
+    );
     let run_result = run_with_termination_signal(
         cancellation_token.clone(),
         RunSignalCleanupContext {
@@ -3845,8 +3938,10 @@ pub(crate) async fn execute_resume(
     }
 
     let amendment_queue = FsAmendmentQueueStore;
-    let retry_policy = RetryPolicy::default_policy()
-        .with_max_remediation_cycles(effective_config.run_policy().max_review_iterations);
+    let retry_policy = apply_test_retry_policy_overrides(
+        RetryPolicy::default_policy()
+            .with_max_remediation_cycles(effective_config.run_policy().max_review_iterations),
+    );
     let run_result = run_with_termination_signal(
         cancellation_token.clone(),
         RunSignalCleanupContext {
@@ -4364,7 +4459,8 @@ pub(crate) async fn execute_sync_milestone(emit_output: bool) -> AppResult<()> {
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::{
-        persist_next_step_recommendation, prepare_milestone_controller_for_execution,
+        apply_test_retry_policy_overrides, persist_next_step_recommendation,
+        prepare_milestone_controller_for_execution,
         repair_missing_interrupted_handoff_run_failed_event,
         repair_missing_interrupted_handoff_run_failed_event_and_reload_snapshot,
         resume_attempt_has_exact_lineage, run_with_termination_signal_waiter,
@@ -4377,6 +4473,8 @@ mod tests {
     use std::collections::BTreeMap;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+    use std::sync::Mutex;
+    use std::time::Duration;
 
     use crate::adapters::bv_process::NextBeadResponse;
     use crate::adapters::fs::{
@@ -4413,12 +4511,43 @@ mod tests {
         self as project_service, CreateProjectInput, JournalStorePort, RunSnapshotPort,
         RunSnapshotWritePort,
     };
-    use crate::shared::domain::{FlowPreset, ProjectId, StageCursor, StageId};
+    use crate::contexts::workflow_composition::retry_policy::RetryPolicy;
+    use crate::shared::domain::{FailureClass, FlowPreset, ProjectId, StageCursor, StageId};
     use crate::shared::error::AppError;
     use crate::test_support::br::{MockBrAdapter, MockBrResponse};
     use crate::test_support::bv::{MockBvAdapter, MockBvResponse};
     use crate::test_support::env::{lock_path_mutex, PathGuard};
     use tokio::sync::oneshot;
+
+    static RETRY_POLICY_ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     fn sample_bundle(id: &str, name: &str) -> MilestoneBundle {
         MilestoneBundle {
@@ -4469,6 +4598,39 @@ mod tests {
             default_flow: FlowPreset::DocsChange,
             agents_guidance: None,
         }
+    }
+
+    #[cfg(feature = "test-stub")]
+    #[test]
+    fn apply_test_retry_policy_overrides_disables_backoff_for_fail_invoke_env() {
+        let _env_lock = RETRY_POLICY_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let _fail_stage = EnvVarGuard::set("RALPH_BURNING_TEST_FAIL_INVOKE_STAGE", "review");
+        let _explicit_override = EnvVarGuard::remove("RALPH_BURNING_TEST_DISABLE_RETRY_BACKOFF");
+
+        let policy = apply_test_retry_policy_overrides(RetryPolicy::default_policy());
+
+        assert_eq!(policy.backoff_for_attempt(1), Duration::ZERO);
+        assert_eq!(policy.max_attempts(FailureClass::TransportFailure), 5);
+    }
+
+    #[cfg(feature = "test-stub")]
+    #[test]
+    fn apply_test_retry_policy_overrides_preserves_default_backoff_without_env() {
+        let _env_lock = RETRY_POLICY_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let _fail_stage = EnvVarGuard::remove("RALPH_BURNING_TEST_FAIL_INVOKE_STAGE");
+        let _explicit_override = EnvVarGuard::remove("RALPH_BURNING_TEST_DISABLE_RETRY_BACKOFF");
+
+        let policy = apply_test_retry_policy_overrides(RetryPolicy::default_policy());
+        let backoff = policy.backoff_for_attempt(1);
+
+        assert!(
+            backoff >= Duration::from_millis(3750) && backoff < Duration::from_millis(6250),
+            "expected jittered default backoff near 5s, got {backoff:?}"
+        );
     }
 
     fn single_bead_bundle(id: &str, name: &str) -> MilestoneBundle {
@@ -4720,6 +4882,26 @@ mod tests {
             .expect("chmod fake br");
     }
 
+    #[cfg(unix)]
+    fn install_fake_br_show_and_list_script(
+        base_dir: &std::path::Path,
+        show_json: &str,
+        list_json: &str,
+    ) {
+        let fake_bin = base_dir.join("fake-bin");
+        std::fs::create_dir_all(&fake_bin).expect("create fake bin");
+
+        let escaped_show_json = show_json.replace('\'', "'\"'\"'");
+        let escaped_list_json = list_json.replace('\'', "'\"'\"'");
+        let script = format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf '%s\\n' 'br test stub'\n  exit 0\nfi\nif [ \"$1\" = \"show\" ] && [ \"$3\" = \"--json\" ]; then\n  printf '%s\\n' '{escaped_show_json}'\n  exit 0\nfi\nif [ \"$1\" = \"list\" ] && [ \"$5\" = \"--json\" ]; then\n  printf '%s\\n' '{escaped_list_json}'\n  exit 0\nfi\nprintf 'unexpected br invocation: %s\\n' \"$*\" >&2\nexit 1\n"
+        );
+        let br_path = fake_bin.join("br");
+        std::fs::write(&br_path, script).expect("write fake br");
+        std::fs::set_permissions(&br_path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake br");
+    }
+
     #[test]
     fn prepare_milestone_controller_for_execution_initializes_claimed_state() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
@@ -4892,6 +5074,69 @@ mod tests {
 
         assert_eq!(
             runtime.bead_status("bead-2").expect("query bead status"),
+            milestone_controller::ControllerBeadStatus::Open
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn milestone_controller_bead_status_falls_back_to_exact_list_lookup_after_wrong_show_result() {
+        let _path_lock = lock_path_mutex();
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let base_dir = temp_dir.path();
+        let now = Utc::now();
+
+        let milestone = create_explicit_bead_milestone_with_plan(
+            base_dir,
+            now,
+            "ms-explicit",
+            "ralph-burning-evi",
+        );
+        install_fake_br_show_and_list_script(
+            base_dir,
+            r#"{
+  "id": "ralph-burning-pfr",
+  "title": "Foreign bead",
+  "status": "closed",
+  "priority": 1,
+  "bead_type": "task",
+  "labels": [],
+  "dependencies": [],
+  "dependents": [],
+  "acceptance_criteria": []
+}"#,
+            r#"{
+  "issues": [
+    {
+      "id": "ralph-burning-pfr",
+      "title": "Foreign bead",
+      "status": "closed",
+      "priority": 1,
+      "bead_type": "task",
+      "labels": []
+    },
+    {
+      "id": "ralph-burning-evi",
+      "title": "Expected explicit bead",
+      "status": "open",
+      "priority": 1,
+      "bead_type": "task",
+      "labels": []
+    }
+  ]
+}"#,
+        );
+        let _path_guard = PathGuard::prepend(&base_dir.join("fake-bin"));
+
+        let runtime = ProjectMilestoneControllerRuntime {
+            base_dir,
+            milestone_id: &milestone.id,
+        };
+
+        assert_eq!(
+            runtime
+                .bead_status("ralph-burning-evi")
+                .expect("the exact list lookup should recover from the wrong show result"),
             milestone_controller::ControllerBeadStatus::Open
         );
     }
@@ -5419,7 +5664,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn select_next_milestone_bead_blocks_when_bv_recommendation_is_outside_the_milestone_plan(
+    async fn select_next_milestone_bead_claims_ready_fallback_when_bv_recommendation_is_outside_the_milestone_plan(
     ) {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let base_dir = temp_dir.path();
@@ -5446,7 +5691,11 @@ mod tests {
 
         assert_eq!(
             controller.state,
-            milestone_controller::MilestoneControllerState::Blocked
+            milestone_controller::MilestoneControllerState::Claimed
+        );
+        assert_eq!(
+            controller.active_bead_id.as_deref(),
+            Some("ms-alpha.bead-2")
         );
         assert!(controller
             .last_transition_reason
@@ -5454,7 +5703,7 @@ mod tests {
             .is_some_and(|reason| {
                 reason.contains("ms-foreign.bead-9")
                     && reason.contains("not part of milestone 'ms-alpha'")
-                    && reason.contains("ready milestone beads: ms-alpha.bead-2")
+                    && reason.contains("claiming ready milestone bead 'ms-alpha.bead-2' instead")
             }));
         assert_eq!(br.calls().len(), 1);
         assert_eq!(br.calls()[0].args, vec!["ready", "--json"]);
@@ -5494,7 +5743,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn select_next_milestone_bead_blocks_when_bv_has_no_recommendation_but_br_ready_is_nonempty(
+    async fn select_next_milestone_bead_claims_ready_fallback_when_bv_has_no_recommendation_but_br_ready_is_nonempty(
     ) {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let base_dir = temp_dir.path();
@@ -5519,14 +5768,18 @@ mod tests {
 
         assert_eq!(
             controller.state,
-            milestone_controller::MilestoneControllerState::Blocked
+            milestone_controller::MilestoneControllerState::Claimed
+        );
+        assert_eq!(
+            controller.active_bead_id.as_deref(),
+            Some("ms-alpha.bead-2")
         );
         assert!(controller
             .last_transition_reason
             .as_deref()
             .is_some_and(|reason| {
                 reason.contains("bv reported no actionable bead")
-                    && reason.contains("ms-alpha.bead-2")
+                    && reason.contains("claiming ready milestone bead 'ms-alpha.bead-2' instead")
             }));
         assert_eq!(br.calls().len(), 1);
         assert_eq!(br.calls()[0].args, vec!["ready", "--json"]);
@@ -12151,6 +12404,19 @@ fn parse_cli_backend_overrides(args: &RunBackendOverrideArgs) -> AppResult<CliBa
             .transpose()?,
         stream_output: args.stream_output,
     })
+}
+
+fn apply_test_retry_policy_overrides(retry_policy: RetryPolicy) -> RetryPolicy {
+    #[cfg(feature = "test-stub")]
+    {
+        if std::env::var_os("RALPH_BURNING_TEST_DISABLE_RETRY_BACKOFF").is_some()
+            || std::env::var_os("RALPH_BURNING_TEST_FAIL_INVOKE_STAGE").is_some()
+        {
+            return retry_policy.with_no_backoff();
+        }
+    }
+
+    retry_policy
 }
 
 fn parse_backend_selection_arg(

--- a/src/contexts/conformance_spec/scenarios.rs
+++ b/src/contexts/conformance_spec/scenarios.rs
@@ -1672,7 +1672,12 @@ fn register_project_records(m: &mut HashMap<String, ScenarioExecutor>) {
         std::fs::remove_file(conformance_project_root(&ws, "corrupt-list").join("project.toml"))
             .map_err(|e| e.to_string())?;
         let out = run_cli(&["project", "list"], ws.path())?;
-        assert_failure(&out)?;
+        assert_success(&out)?;
+        assert_not_contains(
+            &out.stdout,
+            "corrupt-list",
+            "project list should skip partial projects",
+        )?;
         Ok(())
     });
 

--- a/src/contexts/workspace_governance/mod.rs
+++ b/src/contexts/workspace_governance/mod.rs
@@ -45,12 +45,23 @@ pub fn initialize_workspace(
     }
 
     if workspace_root.exists() || audit_root.exists() {
-        return Err(AppError::WorkspaceConflict {
-            path: if workspace_root.exists() {
-                workspace_root
-            } else {
-                audit_root
-            },
+        let config = WorkspaceConfig::new(created_at);
+        let rendered = FileSystem::render_workspace_config(&config)?;
+
+        FileSystem::create_workspace(&audit_root, &rendered, REQUIRED_WORKSPACE_DIRECTORIES)?;
+        FileSystem::seed_live_workspace(base_dir)?;
+
+        if !config_path.is_file() {
+            FileSystem::create_workspace(
+                &workspace_root,
+                &rendered,
+                REQUIRED_WORKSPACE_DIRECTORIES,
+            )?;
+        }
+
+        return Ok(WorkspaceInitialization {
+            workspace_root,
+            config,
         });
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1666,6 +1666,89 @@ fn milestone_next_returns_blocked_json_and_nonzero_status() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("milestone 'ms-blocked' next failed"));
 }
 
+#[test]
+fn milestone_next_claims_ready_fallback_when_bv_recommends_foreign_bead() {
+    let temp_dir = initialize_workspace_fixture();
+    write_single_bead_milestone_fixture(temp_dir.path(), "ms-single");
+
+    let ready_payload = r#"[{"id":"bead-1","title":"Execute the only bead","priority":"P1","issue_type":"task","labels":["single"]}]"#;
+    let show_payload = r#"[
+  {
+    "id": "other-ms.bead-9",
+    "title": "Wrong milestone bead",
+    "status": "open",
+    "priority": "P1",
+    "issue_type": "task",
+    "description": "Belongs elsewhere.",
+    "acceptance_criteria": "- Wrong milestone",
+    "dependencies": [],
+    "dependents": []
+  },
+  {
+    "id": "ms-single.bead-1",
+    "title": "Execute the only bead",
+    "status": "open",
+    "priority": "P1",
+    "issue_type": "task",
+    "description": "Create and run a single bead-backed project.",
+    "acceptance_criteria": "- Single bead completes",
+    "dependencies": [],
+    "dependents": []
+  }
+]"#;
+    let list_payload = r#"{"issues":[{"id":"ms-single.bead-1","title":"Execute the only bead","status":"open","priority":"P1","issue_type":"task","labels":["single"]}]}"#;
+    write_br_milestone_selection_script(temp_dir.path(), ready_payload, show_payload, list_payload);
+    write_bv_next_script(temp_dir.path(), "other-ms.bead-9", "Wrong milestone bead");
+
+    let output = Command::new(binary())
+        .args(["milestone", "next", "ms-single", "--json"])
+        .env("PATH", prepend_path(temp_dir.path()))
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run milestone next with foreign recommendation");
+
+    assert!(
+        output.status.success(),
+        "milestone next should succeed via ready fallback: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse milestone next json");
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["bead"]["id"], "ms-single.bead-1");
+}
+
+#[test]
+fn milestone_next_rejects_execution_when_plan_json_is_missing_during_planning() {
+    let temp_dir = initialize_workspace_fixture();
+
+    let output = Command::new(binary())
+        .args(["milestone", "create", "Alpha Plan"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run milestone create");
+    assert!(
+        output.status.success(),
+        "milestone create should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = Command::new(binary())
+        .args(["milestone", "next", "ms-alpha-plan", "--json"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run milestone next without a plan");
+
+    assert!(
+        !output.status.success(),
+        "milestone next should fail when plan.json is missing"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("milestone 'ms-alpha-plan' next failed"));
+    assert!(stderr.contains("still planning"));
+    assert!(stderr.contains("milestone plan ms-alpha-plan"));
+}
+
 #[cfg(feature = "test-stub")]
 #[test]
 fn milestone_run_ignores_malformed_active_milestone_pointer_and_adopts_existing_project() {
@@ -1742,6 +1825,39 @@ fn milestone_run_ignores_malformed_active_milestone_pointer_and_adopts_existing_
         fs::read_to_string(milestone_root(temp_dir.path(), "ms-single").join("task-runs.ndjson"))
             .expect("read milestone task-runs");
     assert!(task_runs.contains("\"project_id\":\"custom-bead-run\""));
+}
+
+#[cfg(feature = "test-stub")]
+#[test]
+fn milestone_run_rejects_execution_when_plan_json_is_missing_during_planning() {
+    let temp_dir = initialize_workspace_fixture();
+
+    let output = Command::new(binary())
+        .args(["milestone", "create", "Alpha Plan"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run milestone create");
+    assert!(
+        output.status.success(),
+        "milestone create should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = Command::new(binary())
+        .args(["milestone", "run", "ms-alpha-plan", "--json"])
+        .env("RALPH_BURNING_BACKEND", "stub")
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run milestone run without a plan");
+
+    assert!(
+        !output.status.success(),
+        "milestone run should fail when plan.json is missing"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("milestone 'ms-alpha-plan' run failed"));
+    assert!(stderr.contains("still planning"));
+    assert!(stderr.contains("milestone plan ms-alpha-plan"));
 }
 
 #[cfg(feature = "test-stub")]
@@ -6367,7 +6483,7 @@ exit 1
 
     assert!(!output.status.success(), "command unexpectedly succeeded");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("br show returned bead 'ms-alpha.bead-200'"));
+    assert!(stderr.contains("br show returned no matching bead"));
 }
 
 #[test]
@@ -12039,7 +12155,7 @@ fn project_show_fails_fast_when_project_toml_is_missing() {
 }
 
 #[test]
-fn project_list_fails_fast_when_project_toml_is_missing() {
+fn project_list_skips_partial_project_when_project_toml_is_missing() {
     let temp_dir = initialize_workspace_fixture();
     let prompt = write_prompt_fixture(temp_dir.path());
 
@@ -12070,10 +12186,16 @@ fn project_list_fails_fast_when_project_toml_is_missing() {
         .output()
         .expect("run project list");
 
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("project.toml"));
-    assert!(stderr.contains("missing"));
+    assert!(
+        output.status.success(),
+        "project list should skip partial projects: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("good-proj"),
+        "project list should not surface the partial project: {stdout}"
+    );
 }
 
 #[test]

--- a/tests/unit/adapter_contract_test.rs
+++ b/tests/unit/adapter_contract_test.rs
@@ -275,14 +275,14 @@ fn project_store_exists_with_missing_project_toml_returns_corrupt() {
 }
 
 #[test]
-fn project_store_list_with_corrupt_project_toml_returns_error() {
+fn project_store_list_skips_partial_project_without_project_toml() {
     let tmp = tempdir().unwrap();
     setup_workspace(tmp.path());
     fs::create_dir_all(audit_project_root(tmp.path(), "alpha")).unwrap();
 
     let store = FsProjectStore;
-    let err = store.list_project_ids(tmp.path()).unwrap_err();
-    assert!(matches!(err, AppError::CorruptRecord { .. }));
+    let ids = store.list_project_ids(tmp.path()).unwrap();
+    assert!(ids.is_empty());
 }
 
 #[cfg(unix)]

--- a/tests/unit/workspace_test.rs
+++ b/tests/unit/workspace_test.rs
@@ -80,6 +80,34 @@ fn initialize_workspace_fails_when_workspace_already_exists() {
     assert!(second_attempt.is_err());
 }
 
+#[test]
+fn initialize_workspace_repairs_legacy_audit_only_workspace() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let created_at = chrono::Utc
+        .with_ymd_and_hms(2026, 3, 11, 17, 50, 55)
+        .single()
+        .expect("valid timestamp");
+    let audit_root = audit_workspace_root(temp_dir.path());
+    std::fs::create_dir_all(audit_root.join("projects/legacy-project"))
+        .expect("create legacy project directory");
+    std::fs::write(
+        audit_root.join("projects/legacy-project/project.toml"),
+        "id = \"legacy-project\"\nname = \"Legacy\"\nflow = \"minimal\"\nprompt_reference = \"prompt.md\"\nprompt_hash = \"hash\"\ncreated_at = \"2026-03-11T17:50:55Z\"\nstatus_summary = \"created\"\n",
+    )
+    .expect("write legacy project config");
+
+    let result = initialize_workspace(temp_dir.path(), created_at).expect("repair workspace");
+
+    assert_eq!(live_workspace_root(temp_dir.path()), result.workspace_root);
+    assert!(audit_root.join("workspace.toml").is_file());
+    assert!(live_workspace_root(temp_dir.path())
+        .join("workspace.toml")
+        .is_file());
+    assert!(live_workspace_root(temp_dir.path())
+        .join("projects/legacy-project/project.toml")
+        .is_file());
+}
+
 pub(crate) fn initialize_workspace_fixture(base_dir: &Path) -> PathBuf {
     let created_at = chrono::Utc
         .with_ymd_and_hms(2026, 3, 11, 17, 50, 55)


### PR DESCRIPTION
## What changed
- fixed bead-aware milestone/task creation so explicit unqualified bead IDs resolve exactly instead of trusting fuzzy `br show` results
- hardened bead claims against false-negative `br update --status=in_progress` exits by verifying post-update bead state and restoring pending sync metadata
- repaired legacy workspace bootstrap and partial-project listing behavior surfaced during live dogfooding
- made milestone next/run and controller status/resume paths reject missing planning artifacts cleanly and avoid stale or foreign bead resolution
- disabled retry backoff only for `test-stub` fail-invoke scenarios so the full conformance suite no longer stalls during injected transport failures

## Why
Live dogfooding of Ralph Burning on this repo exposed several bead-aware regressions and a conformance hang:
- explicit bead IDs like `ralph-burning-evi` could resolve to the wrong bead through DB-backed `br show`
- `br update` could mutate the bead successfully but still exit with `Issue not found`, causing false claim failures
- the packaged/full conformance path was waiting through retry backoff for intentionally injected failures instead of returning promptly

## Impact
- bead-aware task creation, milestone selection, and iterative-minimal startup work against real repo beads again
- resume/status logic is safer around exact bead identity and missing plan artifacts
- the GitHub Actions conformance job matches local behavior and completes instead of hanging on prompt-change setup scenarios

## Validation
- `nix develop -c cargo fmt --check`
- `nix develop -c cargo clippy --locked -- -D warnings`
- `nix develop -c cargo test --locked --features test-stub`
- `nix develop -c cargo test --locked --features test-stub conformance_full_suite_passes -- --exact`
- `nix develop -c cargo run --locked --features test-stub -- conformance run --filter workflow.resume.prompt_change_continue_warns`
