### PR TITLE
Stabilize iterative-minimal dogfood resume flow

### DIFF
--- a/src/adapters/stub_backend.rs
+++ b/src/adapters/stub_backend.rs
@@ -775,7 +775,7 @@ fn canned_requirements_payload(label: &str) -> serde_json::Value {
                     "flow_override": null
                 }]
             }],
-            "default_flow": "quick_dev",
+            "default_flow": "minimal",
             "agents_guidance": "Follow the milestone plan."
         })
     } else if label.contains("ideation") {

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -217,6 +217,7 @@ async fn handle_create(args: ProjectCreateArgs) -> AppResult<()> {
     // Validate workspace version
     let config = workspace_governance::load_workspace_config(&current_dir)?;
     workspace_governance::ensure_supported_workspace_version(&config)?;
+    let effective_config = EffectiveConfig::load(&current_dir)?;
 
     // Validate project ID
     let project_id = ProjectId::new(args.id.expect("clap should require --id"))?;
@@ -226,7 +227,7 @@ async fn handle_create(args: ProjectCreateArgs) -> AppResult<()> {
         .as_deref()
         .map(str::parse)
         .transpose()?
-        .unwrap_or(FlowPreset::Minimal);
+        .unwrap_or_else(|| effective_config.default_flow());
 
     let prompt_arg = args.prompt.expect("clap should require --prompt");
     let prompt_path = if prompt_arg.is_absolute() {
@@ -2892,7 +2893,7 @@ mod tests {
                     flow_override: Some(FlowPreset::DocsChange),
                 }],
             }],
-            default_flow: FlowPreset::QuickDev,
+            default_flow: FlowPreset::Minimal,
             agents_guidance: None,
         }
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1137,7 +1137,19 @@ fn prepare_milestone_controller_for_execution(
         chrono::Utc::now(),
     )
     .map_err(|error| origin.error(error.to_string()))?;
-    if controller.state == MilestoneControllerState::NeedsOperator {
+    let explicit_resume_retries_same_bead =
+        matches!(origin, MilestoneControllerExecutionOrigin::Resume)
+            && controller.state == MilestoneControllerState::NeedsOperator
+            && controller.active_task_id.as_deref() == Some(project_id.as_str())
+            && controller
+                .active_bead_id
+                .as_deref()
+                .is_some_and(|active_bead_id| {
+                    milestone_bead_refs_match(&milestone_id, active_bead_id, &task_source.bead_id)
+                });
+    if controller.state == MilestoneControllerState::NeedsOperator
+        && !explicit_resume_retries_same_bead
+    {
         return Err(origin.error(
             controller.last_transition_reason.unwrap_or_else(|| {
                 "milestone controller requires operator intervention".to_owned()
@@ -4955,6 +4967,134 @@ mod tests {
             controller.active_task_id.as_deref(),
             Some(project_id.as_str())
         );
+    }
+
+    #[test]
+    fn prepare_milestone_controller_for_resume_allows_operator_retry_on_same_bead() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let base_dir = temp_dir.path();
+        let now = Utc::now();
+
+        let milestone = create_milestone_with_plan(base_dir, now);
+        let project_id = ProjectId::new("bead-run").expect("project id");
+        let project_record = ProjectRecord {
+            id: project_id.clone(),
+            name: "Alpha: Bead".to_owned(),
+            flow: FlowPreset::DocsChange,
+            prompt_reference: "prompt.md".to_owned(),
+            prompt_hash: "prompt-hash".to_owned(),
+            created_at: now,
+            status_summary: ProjectStatusSummary::Active,
+            task_source: Some(TaskSource {
+                milestone_id: milestone.id.to_string(),
+                bead_id: "ms-alpha.bead-2".to_owned(),
+                parent_epic_id: None,
+                origin: TaskOrigin::Milestone,
+                plan_hash: Some("plan-v1".to_owned()),
+                plan_version: Some(2),
+            }),
+        };
+
+        milestone_controller::transition_controller(
+            &FsMilestoneControllerStore,
+            base_dir,
+            &milestone.id,
+            milestone_controller::ControllerTransitionRequest::new(
+                milestone_controller::MilestoneControllerState::NeedsOperator,
+                "bead ms-alpha.bead-2 failed 3 times: transient backend cancellation",
+            )
+            .with_bead("ms-alpha.bead-2")
+            .with_task(project_id.as_str()),
+            now,
+        )
+        .expect("seed needs-operator controller");
+
+        prepare_milestone_controller_for_execution(
+            base_dir,
+            &project_id,
+            &project_record,
+            MilestoneControllerExecutionOrigin::Resume,
+        )
+        .expect("operator resume should be allowed");
+
+        let controller = milestone_controller::load_controller(
+            &FsMilestoneControllerStore,
+            base_dir,
+            &milestone.id,
+        )
+        .expect("load controller")
+        .expect("controller exists");
+        assert_eq!(
+            controller.state,
+            milestone_controller::MilestoneControllerState::Claimed
+        );
+        assert_eq!(
+            controller.active_bead_id.as_deref(),
+            Some("ms-alpha.bead-2")
+        );
+        assert_eq!(
+            controller.active_task_id.as_deref(),
+            Some(project_id.as_str())
+        );
+        assert!(controller.last_transition_reason.as_deref().is_some_and(
+            |reason| reason.contains("preparing the bead-linked project to resume execution")
+        ));
+    }
+
+    #[test]
+    fn prepare_milestone_controller_for_resume_rejects_mismatched_operator_state() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let base_dir = temp_dir.path();
+        let now = Utc::now();
+
+        let milestone = create_milestone_with_plan(base_dir, now);
+        let project_id = ProjectId::new("bead-run").expect("project id");
+        let project_record = ProjectRecord {
+            id: project_id.clone(),
+            name: "Alpha: Bead".to_owned(),
+            flow: FlowPreset::DocsChange,
+            prompt_reference: "prompt.md".to_owned(),
+            prompt_hash: "prompt-hash".to_owned(),
+            created_at: now,
+            status_summary: ProjectStatusSummary::Active,
+            task_source: Some(TaskSource {
+                milestone_id: milestone.id.to_string(),
+                bead_id: "ms-alpha.bead-2".to_owned(),
+                parent_epic_id: None,
+                origin: TaskOrigin::Milestone,
+                plan_hash: Some("plan-v1".to_owned()),
+                plan_version: Some(2),
+            }),
+        };
+
+        milestone_controller::transition_controller(
+            &FsMilestoneControllerStore,
+            base_dir,
+            &milestone.id,
+            milestone_controller::ControllerTransitionRequest::new(
+                milestone_controller::MilestoneControllerState::NeedsOperator,
+                "controller is already tracking a different task",
+            )
+            .with_bead("ms-alpha.bead-2")
+            .with_task("other-task"),
+            now,
+        )
+        .expect("seed mismatched needs-operator controller");
+
+        let error = prepare_milestone_controller_for_execution(
+            base_dir,
+            &project_id,
+            &project_record,
+            MilestoneControllerExecutionOrigin::Resume,
+        )
+        .expect_err("mismatched operator state must still fail");
+
+        match error {
+            AppError::ResumeFailed { reason } => {
+                assert!(reason.contains("different task"));
+            }
+            other => panic!("expected resume failure, got {other:?}"),
+        }
     }
 
     #[cfg(unix)]

--- a/src/contexts/automation_runtime/daemon_loop.rs
+++ b/src/contexts/automation_runtime/daemon_loop.rs
@@ -5349,7 +5349,7 @@ mod tests {
                     flow_override: None,
                 }],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(

--- a/src/contexts/automation_runtime/failure_reconciliation.rs
+++ b/src/contexts/automation_runtime/failure_reconciliation.rs
@@ -1671,7 +1671,7 @@ mod tests {
                     flow_override: None,
                 }],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(

--- a/src/contexts/automation_runtime/success_reconciliation.rs
+++ b/src/contexts/automation_runtime/success_reconciliation.rs
@@ -2172,7 +2172,7 @@ mod tests {
                     flow_override: None,
                 }],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(
@@ -2401,7 +2401,7 @@ mod tests {
                     flow_override: None,
                 }],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(
@@ -2567,7 +2567,7 @@ mod tests {
                     flow_override: None,
                 }],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(
@@ -2806,7 +2806,7 @@ mod tests {
                     },
                 ],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(
@@ -2987,7 +2987,7 @@ mod tests {
                     },
                 ],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(
@@ -3160,7 +3160,7 @@ mod tests {
                     },
                 ],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(
@@ -3305,7 +3305,7 @@ mod tests {
                     flow_override: None,
                 }],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(
@@ -3501,7 +3501,7 @@ mod tests {
                     flow_override: None,
                 }],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(
@@ -3697,7 +3697,7 @@ mod tests {
                     flow_override: None,
                 }],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(
@@ -3869,7 +3869,7 @@ mod tests {
                     },
                 ],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         };
         persist_plan(

--- a/src/contexts/conformance_spec/scenarios.rs
+++ b/src/contexts/conformance_spec/scenarios.rs
@@ -1021,7 +1021,7 @@ fn register_workspace_config(m: &mut HashMap<String, ScenarioExecutor>) {
         init_workspace(&ws)?;
         let out = run_cli(&["config", "get", "default_flow"], ws.path())?;
         assert_success(&out)?;
-        assert_contains(&out.stdout, "quick_dev", "stdout")?;
+        assert_contains(&out.stdout, "minimal", "stdout")?;
         Ok(())
     });
 
@@ -19138,7 +19138,7 @@ fn register_backend_operations_slice5(m: &mut HashMap<String, ScenarioExecutor>)
         // Write config with disabled base backend
         std::fs::write(
             workspace_config_path(ws.path()),
-            "version = 1\ncreated_at = \"2026-03-19T03:28:00Z\"\n\n[settings]\ndefault_backend = \"openrouter\"\n\n[backends.openrouter]\nenabled = false\n",
+            "version = 1\ncreated_at = \"2026-03-19T03:28:00Z\"\n\n[settings]\ndefault_flow = \"standard\"\ndefault_backend = \"openrouter\"\n\n[backends.openrouter]\nenabled = false\n",
         ).map_err(|e| format!("write config: {e}"))?;
 
         let out = run_cli(&["backend", "check", "--json"], ws.path())?;

--- a/src/contexts/milestone_record/bundle.rs
+++ b/src/contexts/milestone_record/bundle.rs
@@ -73,7 +73,7 @@ impl MilestoneBundle {
             constraints: Vec::new(),
             acceptance_map: Vec::new(),
             workstreams: Vec::new(),
-            default_flow: FlowPreset::QuickDev,
+            default_flow: FlowPreset::Minimal,
             agents_guidance: None,
         }
     }
@@ -1999,7 +1999,7 @@ mod tests {
                     },
                 ],
             }],
-            default_flow: FlowPreset::QuickDev,
+            default_flow: FlowPreset::Minimal,
             agents_guidance: Some("Follow existing patterns in src/contexts/.".to_owned()),
         }
     }
@@ -3062,7 +3062,7 @@ mod tests {
                     ],
                 },
             ],
-            default_flow: FlowPreset::QuickDev,
+            default_flow: FlowPreset::Minimal,
             agents_guidance: None,
         };
 
@@ -3185,7 +3185,7 @@ mod tests {
                     }],
                 },
             ],
-            default_flow: FlowPreset::QuickDev,
+            default_flow: FlowPreset::Minimal,
             agents_guidance: None,
         };
 
@@ -3292,7 +3292,7 @@ mod tests {
         assert!(md.contains("## Execution Defaults"));
         assert!(md.contains("## AGENTS Guidance"));
         assert!(md.contains("- **Milestone ID:** ms-alpha"));
-        assert!(md.contains("quick_dev"));
+        assert!(md.contains("minimal"));
         Ok(())
     }
 

--- a/src/contexts/milestone_record/service.rs
+++ b/src/contexts/milestone_record/service.rs
@@ -5465,7 +5465,7 @@ mod tests {
                     flow_override: None,
                 }],
             }],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         }
     }
@@ -5634,7 +5634,7 @@ mod tests {
                     ],
                 },
             ],
-            default_flow: crate::shared::domain::FlowPreset::QuickDev,
+            default_flow: crate::shared::domain::FlowPreset::Minimal,
             agents_guidance: None,
         }
     }

--- a/src/contexts/project_run_record/service.rs
+++ b/src/contexts/project_run_record/service.rs
@@ -2800,7 +2800,7 @@ mod tests {
                     flow_override: None,
                 }],
             }],
-            default_flow: FlowPreset::QuickDev,
+            default_flow: FlowPreset::Minimal,
             agents_guidance: None,
         }
     }

--- a/src/contexts/workflow_composition/engine.rs
+++ b/src/contexts/workflow_composition/engine.rs
@@ -6786,11 +6786,35 @@ fn iterative_fingerprint_excludes_path(relative_path: &Path) -> bool {
     matches!(first_component.as_ref(), ".git" | ".ralph-burning")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IterativeFingerprintMode {
+    Content,
+    ChangeScope,
+}
+
+fn iterative_stability_fingerprint_mode(
+    pending_amendments: Option<&[QueuedAmendment]>,
+) -> IterativeFingerprintMode {
+    if pending_amendments.is_some_and(|amendments| !amendments.is_empty()) {
+        IterativeFingerprintMode::ChangeScope
+    } else {
+        IterativeFingerprintMode::Content
+    }
+}
+
 fn iterative_fingerprint_git_pathspecs() -> Vec<&'static str> {
     vec![
         ".",
         ":(top,exclude).ralph-burning",
         ":(top,glob,exclude).ralph-burning/**",
+        ":(top,exclude)target",
+        ":(top,glob,exclude)target/**",
+        ":(top,exclude)target-final",
+        ":(top,glob,exclude)target-final/**",
+        ":(top,exclude)result",
+        ":(top,glob,exclude)result/**",
+        ":(top,glob,exclude)result-*",
+        ":(top,glob,exclude)result-*/**",
     ]
 }
 
@@ -6867,6 +6891,57 @@ fn workspace_diff_fingerprint(workspace_root: &Path) -> AppResult<String> {
     let mut hasher = Sha256::new();
     hash_workspace_entries(workspace_root, workspace_root, &mut hasher)?;
     Ok(format!("fs:{:x}", hasher.finalize()))
+}
+
+fn hash_workspace_entries_for_change_scope(
+    workspace_root: &Path,
+    current: &Path,
+    hasher: &mut Sha256,
+) -> AppResult<()> {
+    let mut entries = fs::read_dir(current)?.collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let path = entry.path();
+        let relative_path = path.strip_prefix(workspace_root).unwrap_or(path.as_path());
+        if iterative_fingerprint_excludes_path(relative_path) {
+            continue;
+        }
+        let relative = relative_path.to_string_lossy();
+
+        let metadata = fs::symlink_metadata(&path)?;
+        if iterative_workspace_build_artifact(relative_path, &metadata) {
+            continue;
+        }
+        if metadata.is_dir() {
+            hasher.update(b"dir\0");
+            hasher.update(relative.as_bytes());
+            hash_metadata_mode(&metadata, hasher);
+            hash_workspace_entries_for_change_scope(workspace_root, &path, hasher)?;
+            continue;
+        }
+
+        if metadata.file_type().is_symlink() {
+            hasher.update(b"symlink\0");
+            hasher.update(relative.as_bytes());
+            hash_metadata_mode(&metadata, hasher);
+            continue;
+        }
+
+        if metadata.is_file() {
+            hasher.update(b"file\0");
+            hasher.update(relative.as_bytes());
+            hash_metadata_mode(&metadata, hasher);
+        }
+    }
+
+    Ok(())
+}
+
+fn workspace_change_scope_fingerprint(workspace_root: &Path) -> AppResult<String> {
+    let mut hasher = Sha256::new();
+    hash_workspace_entries_for_change_scope(workspace_root, workspace_root, &mut hasher)?;
+    Ok(format!("fs-scope:{:x}", hasher.finalize()))
 }
 
 fn git_command_for_program(program: &str) -> Command {
@@ -7111,6 +7186,43 @@ fn git_diff_fingerprint(repo_root: &Path) -> AppResult<String> {
     Ok(format!("git:{:x}", hasher.finalize()))
 }
 
+fn git_change_scope_fingerprint(repo_root: &Path) -> AppResult<String> {
+    if !git_repo_available(repo_root)? {
+        return workspace_change_scope_fingerprint(repo_root);
+    }
+
+    let status = git_command_stdout(
+        repo_root,
+        &git_args_with_iterative_fingerprint_pathspecs(&[
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            "--",
+        ]),
+        "status --porcelain",
+    )?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"head\0");
+    hasher.update(git_head_fingerprint(repo_root));
+    hasher.update(b"status\0");
+    hasher.update(&status);
+    hash_git_empty_directories(repo_root, repo_root, &mut hasher)?;
+
+    Ok(format!("git-scope:{:x}", hasher.finalize()))
+}
+
+fn iterative_loop_fingerprint(
+    repo_root: &Path,
+    mode: IterativeFingerprintMode,
+) -> AppResult<String> {
+    match mode {
+        IterativeFingerprintMode::Content => git_diff_fingerprint(repo_root),
+        IterativeFingerprintMode::ChangeScope => git_change_scope_fingerprint(repo_root),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn execute_iterative_plan_and_implement_stage<A, R, S>(
     agent_service: &AgentExecutionService<A, R, S>,
@@ -7156,6 +7268,7 @@ where
         &resolved_target,
         stage_entry.stage_id,
     )?;
+    let fingerprint_mode = iterative_stability_fingerprint_mode(pending_amendments);
     let mut stable_count = persisted_state.stable_count;
     let mut iteration = persisted_state.completed_iterations;
     loop {
@@ -7219,7 +7332,7 @@ where
             });
         }
 
-        let diff_before = git_diff_fingerprint(repo_root)?;
+        let diff_before = iterative_loop_fingerprint(repo_root, fingerprint_mode)?;
         let iterative_invocation_context = json!({
             "iteration": iteration,
             "iterative_minimal": {
@@ -7251,7 +7364,7 @@ where
             Err(error) => return Err(error),
         };
 
-        let diff_after = git_diff_fingerprint(repo_root)?;
+        let diff_after = iterative_loop_fingerprint(repo_root, fingerprint_mode)?;
         let diff_changed = diff_before != diff_after;
         let outcome = iterative_iteration_outcome(&bundle);
 
@@ -10211,11 +10324,12 @@ mod tests {
     use super::{
         advance_iterative_loop_state, build_final_review_snapshot, build_prompt_review_snapshot,
         complete_run, drift_still_satisfies_requirements, failed_invocation_id_for_stage,
-        git_diff_fingerprint, git_repo_available_with_program, invocation_id_for_stage,
-        iterative_loop_exit_reason, mark_running_run_interrupted, milestone_lineage_plan_hash,
-        partition_final_review_amendments_by_route, pause_run, resolution_has_drifted,
-        resume_iteration_counters, resume_run_with_retry, resume_terminal_iterative_stage_result,
-        role_for_stage, stage_running_summary_for_active_run, sync_milestone_bead_start,
+        git_change_scope_fingerprint, git_diff_fingerprint, git_repo_available_with_program,
+        invocation_id_for_stage, iterative_loop_exit_reason, mark_running_run_interrupted,
+        milestone_lineage_plan_hash, partition_final_review_amendments_by_route, pause_run,
+        resolution_has_drifted, resume_iteration_counters, resume_run_with_retry,
+        resume_terminal_iterative_stage_result, role_for_stage,
+        stage_running_summary_for_active_run, sync_milestone_bead_start,
         validate_iterative_minimal_loop_settings, FinalReviewQueuedAmendment,
         InterruptedRunContext, InterruptedRunUpdate, IterativeInvocationSidecar,
         IterativeLoopExitReason, QueuedAmendment, RunningAttemptIdentity, StagePlan,
@@ -11170,7 +11284,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn git_diff_fingerprint_detects_tracked_result_symlink_changes() {
+    fn git_diff_fingerprint_ignores_tracked_result_symlink_changes() {
         let temp_dir = tempdir().expect("create temp dir");
         let store_dir = tempdir().expect("create store dir");
         init_git_repo(temp_dir.path());
@@ -11189,9 +11303,9 @@ mod tests {
         std::os::unix::fs::symlink(&store_b, &result_path).expect("recreate result symlink");
 
         let changed = git_diff_fingerprint(temp_dir.path()).expect("changed fingerprint");
-        assert_ne!(
+        assert_eq!(
             baseline, changed,
-            "tracked result symlink changes must remain visible"
+            "tracked result symlink churn must be ignored for iterative stability"
         );
     }
 
@@ -11217,6 +11331,53 @@ mod tests {
         assert_ne!(
             first, second,
             "tracked content changes on an already-dirty file must change the fingerprint"
+        );
+    }
+
+    #[test]
+    fn git_change_scope_fingerprint_ignores_dirty_tracked_content_rewrites() {
+        let temp_dir = tempdir().expect("create temp dir");
+        init_git_repo(temp_dir.path());
+
+        fs::write(
+            temp_dir.path().join("tracked.txt"),
+            "baseline\nchanged once\n",
+        )
+        .expect("modify tracked file");
+        let first = git_change_scope_fingerprint(temp_dir.path()).expect("first fingerprint");
+
+        fs::write(
+            temp_dir.path().join("tracked.txt"),
+            "baseline\nchanged twice\n",
+        )
+        .expect("modify tracked file again");
+        let second = git_change_scope_fingerprint(temp_dir.path()).expect("second fingerprint");
+
+        assert_eq!(
+            first, second,
+            "change-scope fingerprint should stay stable when the dirty path set is unchanged"
+        );
+    }
+
+    #[test]
+    fn git_change_scope_fingerprint_changes_when_dirty_path_set_expands() {
+        let temp_dir = tempdir().expect("create temp dir");
+        init_git_repo(temp_dir.path());
+
+        fs::write(
+            temp_dir.path().join("tracked.txt"),
+            "baseline\nchanged once\n",
+        )
+        .expect("modify tracked file");
+        let first = git_change_scope_fingerprint(temp_dir.path()).expect("first fingerprint");
+
+        fs::write(temp_dir.path().join("second.txt"), "new dirty path\n")
+            .expect("modify second tracked file");
+        let second = git_change_scope_fingerprint(temp_dir.path()).expect("second fingerprint");
+
+        assert_ne!(
+            first, second,
+            "change-scope fingerprint must still react when a new dirty path is introduced"
         );
     }
 

--- a/src/contexts/workspace_governance/config.rs
+++ b/src/contexts/workspace_governance/config.rs
@@ -20,8 +20,8 @@ use super::{load_workspace_config, workspace_config_path};
 
 /// Default: enabled.
 pub const DEFAULT_PROMPT_REVIEW_ENABLED: bool = true;
-/// Default: quick_dev.
-pub const DEFAULT_FLOW_PRESET: FlowPreset = FlowPreset::QuickDev;
+/// Default: minimal.
+pub const DEFAULT_FLOW_PRESET: FlowPreset = FlowPreset::Minimal;
 pub const DEFAULT_MAX_QA_ITERATIONS: u32 = 3;
 pub const DEFAULT_MAX_REVIEW_ITERATIONS: u32 = 3;
 pub const DEFAULT_PROMPT_REVIEW_MIN_REVIEWERS: usize = 2;
@@ -616,7 +616,7 @@ impl EffectiveConfig {
         self.prompt_review_policy.enabled
     }
 
-    /// Default: `standard`.
+    /// Default: `minimal`.
     pub fn default_flow(&self) -> FlowPreset {
         self.run_policy.default_flow
     }

--- a/src/test_support/e2e_fixtures.rs
+++ b/src/test_support/e2e_fixtures.rs
@@ -223,7 +223,7 @@ fn scenario_bundle() -> MilestoneBundle {
                 }],
             },
         ],
-        default_flow: FlowPreset::QuickDev,
+        default_flow: FlowPreset::Minimal,
         agents_guidance: Some(
             "Use the staged milestone artifacts and shared mock adapter state instead of real tooling."
                 .to_owned(),

--- a/src/test_support/fixtures.rs
+++ b/src/test_support/fixtures.rs
@@ -505,7 +505,7 @@ impl MilestoneFixtureBuilder {
                     flow_override: None,
                 }],
             }],
-            default_flow: FlowPreset::QuickDev,
+            default_flow: FlowPreset::Minimal,
             status: MilestoneStatus::Ready,
             created_at: fixture_timestamp(),
             task_runs: Vec::new(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -691,7 +691,7 @@ created_at = "2026-04-01T10:00:00Z"
                 },
             ],
         }],
-        default_flow: FlowPreset::QuickDev,
+        default_flow: FlowPreset::Minimal,
         agents_guidance: Some("Keep changes inspectable and deterministic.".to_owned()),
     };
     let plan_json = render_plan_json(&bundle).expect("render plan json");
@@ -769,7 +769,7 @@ created_at = "2026-04-01T10:00:00Z"
                 flow_override: Some(FlowPreset::DocsChange),
             }],
         }],
-        default_flow: FlowPreset::QuickDev,
+        default_flow: FlowPreset::Minimal,
         agents_guidance: Some("Run the single bead deterministically.".to_owned()),
     };
     let plan_json = render_plan_json(&bundle).expect("render plan json");
@@ -3199,7 +3199,7 @@ fn config_show_prints_effective_values_and_sources() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("[settings]"));
     assert!(stdout.contains("prompt_review.enabled = true # source: default"));
-    assert!(stdout.contains("default_flow = \"quick_dev\" # source: default"));
+    assert!(stdout.contains("default_flow = \"minimal\" # source: default"));
     assert!(stdout.contains("default_backend = \"claude\" # source: default"));
 }
 
@@ -3809,7 +3809,7 @@ fn config_get_prints_known_values_and_rejects_unknown_keys() {
         .output()
         .expect("run config get");
     assert!(known.status.success());
-    assert_eq!("quick_dev\n", String::from_utf8_lossy(&known.stdout));
+    assert_eq!("minimal\n", String::from_utf8_lossy(&known.stdout));
 
     let unknown = Command::new(binary())
         .args(["config", "get", "unknown.key"])
@@ -4150,6 +4150,53 @@ fn project_create_defaults_to_minimal_flow_without_flag() {
 }
 
 #[test]
+fn project_create_uses_workspace_configured_default_flow_without_flag() {
+    let temp_dir = initialize_workspace_fixture();
+    let prompt = write_prompt_fixture(temp_dir.path());
+
+    let config = Command::new(binary())
+        .args(["config", "set", "default_flow", "standard"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("set workspace default flow");
+    assert!(
+        config.status.success(),
+        "config set failed: {}",
+        String::from_utf8_lossy(&config.stderr)
+    );
+
+    let output = Command::new(binary())
+        .args([
+            "project",
+            "create",
+            "--id",
+            "workspace-default",
+            "--name",
+            "Workspace Default",
+            "--prompt",
+            prompt.to_str().unwrap(),
+        ])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run project create");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Created project 'workspace-default'"));
+    assert!(stdout.contains("standard"));
+
+    let project_toml =
+        fs::read_to_string(project_root(temp_dir.path(), "workspace-default").join("project.toml"))
+            .expect("read project.toml");
+    assert!(project_toml.contains("flow = \"standard\""));
+}
+
+#[test]
 fn project_create_accepts_iterative_minimal_flow() {
     let temp_dir = initialize_workspace_fixture();
     let prompt = write_prompt_fixture(temp_dir.path());
@@ -4182,6 +4229,41 @@ fn project_create_accepts_iterative_minimal_flow() {
     )
     .expect("read project.toml");
     assert!(project_toml.contains("flow = \"iterative_minimal\""));
+}
+
+#[test]
+fn project_create_accepts_standard_flow_override() {
+    let temp_dir = initialize_workspace_fixture();
+    let prompt = write_prompt_fixture(temp_dir.path());
+
+    let output = Command::new(binary())
+        .args([
+            "project",
+            "create",
+            "--id",
+            "standard-override-project",
+            "--name",
+            "Standard Override Project",
+            "--prompt",
+            prompt.to_str().unwrap(),
+            "--flow",
+            "standard",
+        ])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run project create");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let project_toml = fs::read_to_string(
+        project_root(temp_dir.path(), "standard-override-project").join("project.toml"),
+    )
+    .expect("read project.toml");
+    assert!(project_toml.contains("flow = \"standard\""));
 }
 
 #[test]
@@ -4519,6 +4601,96 @@ exit 1
     assert!(prompt.contains(
         "Summary:\n    Capture the operator-facing workflow once project creation is stable."
     ));
+}
+
+#[cfg(feature = "test-stub")]
+#[test]
+fn project_create_from_bead_uses_stub_generated_milestone_default_flow_without_override() {
+    let temp_dir = initialize_workspace_fixture();
+
+    let create_output = Command::new(binary())
+        .args([
+            "milestone",
+            "create",
+            "Alpha Plan",
+            "--from-idea",
+            "Plan the alpha milestone in milestone mode.",
+        ])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run milestone create");
+    assert!(
+        create_output.status.success(),
+        "milestone create should succeed: {}",
+        String::from_utf8_lossy(&create_output.stderr)
+    );
+
+    let plan_output = Command::new(binary())
+        .args(["milestone", "plan", "ms-alpha-plan"])
+        .env("RALPH_BURNING_BACKEND", "stub")
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run milestone plan");
+    assert!(
+        plan_output.status.success(),
+        "milestone plan should succeed: {}",
+        String::from_utf8_lossy(&plan_output.stderr)
+    );
+
+    let plan_json =
+        fs::read_to_string(milestone_root(temp_dir.path(), "ms-alpha-plan").join("plan.json"))
+            .expect("read plan json");
+    let plan: serde_json::Value = serde_json::from_str(&plan_json).expect("parse plan json");
+    let bead = &plan["workstreams"][0]["beads"][0];
+    let bead_id = bead["bead_id"].as_str().expect("stub milestone bead id");
+    let bead_title = bead["title"].as_str().expect("stub milestone bead title");
+
+    let fake_br = write_show_bead_script_with_default_list(
+        temp_dir.path(),
+        bead_id,
+        &format!(
+            r#"[
+  {{
+    "id": "{bead_id}",
+    "title": "{bead_title}",
+    "status": "open",
+    "priority": "P1",
+    "issue_type": "task",
+    "description": "Carry the milestone plan into execution.",
+    "acceptance_criteria": "- Milestone can be executed from structured plan output.",
+    "dependencies": []
+  }}
+]"#
+        ),
+    );
+    let path = prepend_path(fake_br.parent().expect("fake br parent"));
+
+    let output = Command::new(binary())
+        .args([
+            "project",
+            "create-from-bead",
+            "--milestone-id",
+            "ms-alpha-plan",
+            "--bead-id",
+            bead_id,
+            "--project-id",
+            "stub-generated-default",
+        ])
+        .env("PATH", path)
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("run project create-from-bead");
+    assert!(
+        output.status.success(),
+        "project create-from-bead should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let project_toml = fs::read_to_string(
+        project_root(temp_dir.path(), "stub-generated-default").join("project.toml"),
+    )
+    .expect("read project.toml");
+    assert!(project_toml.contains("flow = \"minimal\""));
 }
 
 #[cfg(feature = "test-stub")]
@@ -5928,7 +6100,7 @@ fn project_create_from_bead_treats_legacy_qualified_canonical_slot_ids_as_unconf
         project_root(temp_dir.path(), "legacy-qualified-slot-id-project").join("project.toml"),
     )
     .expect("read project.toml");
-    assert!(project_toml.contains("flow = \"quick_dev\""));
+    assert!(project_toml.contains("flow = \"minimal\""));
     assert!(!project_toml.contains(&format!("plan_hash = \"{plan_hash}\"")));
     assert!(!project_toml.contains("plan_version = "));
 }
@@ -6027,7 +6199,7 @@ fn project_create_from_bead_treats_legacy_short_canonical_slot_ids_as_unconfirme
         project_root(temp_dir.path(), "legacy-short-bead-id-project").join("project.toml"),
     )
     .expect("read project.toml");
-    assert!(project_toml.contains("flow = \"quick_dev\""));
+    assert!(project_toml.contains("flow = \"minimal\""));
     assert!(!project_toml.contains(&format!("plan_hash = \"{plan_hash}\"")));
     assert!(!project_toml.contains("plan_version = "));
 }
@@ -6295,7 +6467,7 @@ fn project_create_from_bead_allows_unconfirmed_fallback_when_status_metadata_is_
         project_root(temp_dir.path(), "stale-status-unconfirmed-fallback").join("project.toml"),
     )
     .expect("read project.toml");
-    assert!(project_toml.contains("flow = \"quick_dev\""));
+    assert!(project_toml.contains("flow = \"minimal\""));
     assert!(!project_toml.contains("plan_version = "));
     assert!(!project_toml.contains("plan_hash = "));
 }
@@ -6588,7 +6760,7 @@ fn project_create_from_bead_falls_back_to_milestone_default_flow_when_title_drif
         project_root(temp_dir.path(), "renamed-live-bead-default-flow").join("project.toml"),
     )
     .expect("read project.toml");
-    assert!(project_toml.contains("flow = \"quick_dev\""));
+    assert!(project_toml.contains("flow = \"minimal\""));
     assert!(!project_toml.contains("plan_version = "));
     assert!(!project_toml.contains("plan_hash = "));
 
@@ -6966,7 +7138,7 @@ fn project_create_from_bead_does_not_confirm_title_fallback_against_mismatched_e
         project_root(temp_dir.path(), "mismatched-explicit-bead-id").join("project.toml"),
     )
     .expect("read project.toml");
-    assert!(project_toml.contains("flow = \"quick_dev\""));
+    assert!(project_toml.contains("flow = \"minimal\""));
     assert!(!project_toml.contains("plan_version = "));
     assert!(!project_toml.contains("plan_hash = "));
 
@@ -17268,6 +17440,7 @@ fn backend_check_nonzero_exit_on_failure() {
 created_at = "2026-03-19T03:28:00Z"
 
 [settings]
+default_flow = "standard"
 default_backend = "openrouter"
 
 [backends.openrouter]
@@ -17325,6 +17498,7 @@ fn backend_probe_nonzero_exit_on_disabled_backend() {
 created_at = "2026-03-19T03:28:00Z"
 
 [settings]
+default_flow = "standard"
 default_backend = "openrouter"
 
 [backends.openrouter]
@@ -17402,6 +17576,7 @@ fn backend_check_nonzero_exit_json_reports_failures() {
 created_at = "2026-03-19T03:28:00Z"
 
 [settings]
+default_flow = "standard"
 default_backend = "openrouter"
 
 [backends.openrouter]

--- a/tests/conformance/features/workspace_config.feature
+++ b/tests/conformance/features/workspace_config.feature
@@ -15,7 +15,7 @@ Feature: Workspace effective configuration
   Scenario: get a known key
     Given the current directory contains an initialized ".ralph-burning" workspace
     When I run "ralph-burning config get default_flow"
-    Then the output should include "standard"
+    Then the output should include "minimal"
     And the command should exit successfully
 
   @workspace-config-get-unknown

--- a/tests/unit/process_backend_test.rs
+++ b/tests/unit/process_backend_test.rs
@@ -2888,11 +2888,11 @@ sleep 99999
         .expect("child PID file should contain an integer");
 
     wait_for_condition(Duration::from_secs(1), Duration::from_millis(25), || {
-        !nix::sys::signal::kill(
+        nix::sys::signal::kill(
             nix::unistd::Pid::from_raw(child_pid),
             None, // signal 0
         )
-        .is_ok()
+        .is_err()
     })
     .await;
 

--- a/tests/unit/workflow_engine_test.rs
+++ b/tests/unit/workflow_engine_test.rs
@@ -3029,6 +3029,71 @@ async fn iterative_minimal_detects_changes_to_already_dirty_files() {
 }
 
 #[tokio::test]
+async fn iterative_minimal_amendment_round_stabilizes_on_change_scope() {
+    let tmp = tempdir().unwrap();
+    let base_dir = tmp.path();
+
+    setup_workspace(base_dir);
+    init_git_repo(base_dir);
+    let pid = create_project_with_flow(
+        base_dir,
+        "iter-amendment-scope",
+        FlowPreset::IterativeMinimal,
+    );
+
+    let adapter = AmendmentRoundDirtyFileIterativePlanAdapter::new();
+    let adapter_handle = adapter.clone();
+    let agent_service = build_agent_service_with_adapter(adapter);
+    let config = EffectiveConfig::load(base_dir).unwrap();
+
+    let result = engine::execute_run(
+        &agent_service,
+        &FsRunSnapshotStore,
+        &FsRunSnapshotWriteStore,
+        &FsJournalStore,
+        &FsPayloadArtifactWriteStore,
+        &FsRuntimeLogWriteStore,
+        &FsAmendmentQueueStore,
+        base_dir,
+        &pid,
+        FlowPreset::IterativeMinimal,
+        &config,
+    )
+    .await;
+
+    assert!(result.is_ok(), "{result:?}");
+    assert_eq!(
+        adapter_handle.plan_calls(),
+        6,
+        "the amendment round should converge once the rewritten path scope stops expanding"
+    );
+    assert_eq!(adapter_handle.amendment_round_calls(), 3);
+
+    let events = FsJournalStore.read_journal(base_dir, &pid).unwrap();
+    let round_two_completed: Vec<_> = events
+        .iter()
+        .filter(|event| {
+            event.event_type == JournalEventType::ImplementerIterationCompleted
+                && event.details["completion_round"].as_u64() == Some(2)
+        })
+        .collect();
+    assert_eq!(round_two_completed.len(), 3);
+    assert_eq!(round_two_completed[0].details["diff_changed"], true);
+    assert_eq!(round_two_completed[1].details["diff_changed"], false);
+    assert_eq!(round_two_completed[2].details["diff_changed"], false);
+
+    let round_two_exit = events
+        .iter()
+        .find(|event| {
+            event.event_type == JournalEventType::ImplementerLoopExited
+                && event.details["completion_round"].as_u64() == Some(2)
+        })
+        .expect("round-two implementer_loop_exited event");
+    assert_eq!(round_two_exit.details["reason"], "stable");
+    assert_eq!(round_two_exit.details["total_iterations"], 3);
+}
+
+#[tokio::test]
 async fn iterative_minimal_resume_after_terminal_loop_does_not_reinvoke_implementer() {
     let tmp = tempdir().unwrap();
     let base_dir = tmp.path();
@@ -3638,11 +3703,7 @@ async fn preflight_check_validates_final_review_arbiter_member() {
 
     let workspace_toml = workspace_config_path(temp.path());
     let content = fs::read_to_string(&workspace_toml).unwrap();
-    let patched = if content.contains("[workflow]") {
-        format!("{content}\n[final_review]\narbiter_backend = \"openrouter\"\n")
-    } else {
-        format!("{content}\n[final_review]\narbiter_backend = \"openrouter\"\n")
-    };
+    let patched = format!("{content}\n[final_review]\narbiter_backend = \"openrouter\"\n");
     fs::write(&workspace_toml, patched).unwrap();
 
     let config = EffectiveConfig::load(temp.path()).unwrap();
@@ -4807,6 +4868,77 @@ impl AgentExecutionPort for DirtyFileIterativePlanAdapter {
 }
 
 #[derive(Clone)]
+struct AmendmentRoundDirtyFileIterativePlanAdapter {
+    inner: StubBackendAdapter,
+    plan_calls: Arc<AtomicU32>,
+    amendment_round_calls: Arc<AtomicU32>,
+}
+
+impl AmendmentRoundDirtyFileIterativePlanAdapter {
+    fn new() -> Self {
+        Self {
+            inner: StubBackendAdapter::default().with_stage_payload_sequence(
+                StageId::FinalReview,
+                vec![
+                    conditionally_approved_payload(&["fix something"]),
+                    approved_validation_payload(),
+                ],
+            ),
+            plan_calls: Arc::new(AtomicU32::new(0)),
+            amendment_round_calls: Arc::new(AtomicU32::new(0)),
+        }
+    }
+
+    fn plan_calls(&self) -> u32 {
+        self.plan_calls.load(Ordering::SeqCst)
+    }
+
+    fn amendment_round_calls(&self) -> u32 {
+        self.amendment_round_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl AgentExecutionPort for AmendmentRoundDirtyFileIterativePlanAdapter {
+    async fn check_capability(
+        &self,
+        backend: &ralph_burning::shared::domain::ResolvedBackendTarget,
+        contract: &ralph_burning::contexts::agent_execution::model::InvocationContract,
+    ) -> AppResult<()> {
+        self.inner.check_capability(backend, contract).await
+    }
+
+    async fn check_availability(
+        &self,
+        backend: &ralph_burning::shared::domain::ResolvedBackendTarget,
+    ) -> AppResult<()> {
+        self.inner.check_availability(backend).await
+    }
+
+    async fn invoke(&self, request: InvocationRequest) -> AppResult<InvocationEnvelope> {
+        if request.contract.stage_id() == Some(StageId::PlanAndImplement) {
+            let call = self.plan_calls.fetch_add(1, Ordering::SeqCst) + 1;
+            let path = request.working_dir.join("iterative-output.txt");
+            if request.invocation_id.contains("-cr2-") {
+                let amendment_call = self.amendment_round_calls.fetch_add(1, Ordering::SeqCst) + 1;
+                fs::write(
+                    &path,
+                    format!("changed in amendment round {amendment_call}\n"),
+                )
+                .expect("write amendment-round iterative output");
+            } else if call == 1 {
+                fs::write(&path, "changed once\n").expect("write first iterative output");
+            }
+        }
+
+        self.inner.invoke(request).await
+    }
+
+    async fn cancel(&self, invocation_id: &str) -> AppResult<()> {
+        self.inner.cancel(invocation_id).await
+    }
+}
+
+#[derive(Clone)]
 struct ParsedPayloadPersistenceFailureAdapter {
     inner: StubBackendAdapter,
     plan_calls: Arc<AtomicU32>,
@@ -4847,9 +4979,11 @@ impl AgentExecutionPort for ParsedPayloadPersistenceFailureAdapter {
         let project_root = request.project_root.clone();
         let working_dir = request.working_dir.clone();
 
-        let call = is_plan
-            .then(|| self.plan_calls.fetch_add(1, Ordering::SeqCst) + 1)
-            .unwrap_or(0);
+        let call = if is_plan {
+            self.plan_calls.fetch_add(1, Ordering::SeqCst) + 1
+        } else {
+            0
+        };
         if call == 1 {
             fs::write(working_dir.join("iterative-output.txt"), "changed once\n")
                 .expect("write iterative output");


### PR DESCRIPTION
## Summary
- stabilize iterative-minimal amendment handling and related regression coverage
- preserve bead-linked task state across milestone sync/reconciliation paths
- allow explicit `run resume` to recover the same operator-escalated bead/task

## Validation
- `nix develop -c cargo test --test unit workflow_engine_test::iterative_minimal_amendment_round_stabilizes_on_change_scope --features test-stub -- --exact --nocapture`
- `nix develop -c cargo test --lib prepare_milestone_controller_for_ -- --nocapture`
- `nix build`