### PR TITLE
refactor(workflow): make docs_change flow an alias of minimal (ralph-burning-gp7)

### DIFF
--- a/src/contexts/conformance_spec/scenarios.rs
+++ b/src/contexts/conformance_spec/scenarios.rs
@@ -2437,6 +2437,8 @@ fn register_run_start_quick_dev(m: &mut HashMap<String, ScenarioExecutor>) {
 // ===========================================================================
 
 fn register_run_start_docs_change(m: &mut HashMap<String, ScenarioExecutor>) {
+    // `docs_change` is an alias of `minimal` — the preset name is accepted
+    // for UX clarity but the underlying stage plan is the minimal one.
     reg!(m, "SC-DOCS-START-001", || {
         let ws = TempWorkspace::new()?;
         setup_workspace_with_project(&ws, "docs-happy", "docs_change")?;
@@ -2451,8 +2453,8 @@ fn register_run_start_docs_change(m: &mut HashMap<String, ScenarioExecutor>) {
         let ws = TempWorkspace::new()?;
         let out = run_cli(&["flow", "show", "docs_change"], ws.path())?;
         assert_success(&out)?;
-        assert_contains(&out.stdout, "docs_update", "stdout")?;
-        assert_contains(&out.stdout, "docs_validation", "stdout")?;
+        assert_contains(&out.stdout, "plan_and_implement", "stdout")?;
+        assert_contains(&out.stdout, "final_review", "stdout")?;
         Ok(())
     });
 
@@ -2460,7 +2462,14 @@ fn register_run_start_docs_change(m: &mut HashMap<String, ScenarioExecutor>) {
         let ws = TempWorkspace::new()?;
         let out = run_cli(&["flow", "show", "docs_change"], ws.path())?;
         assert_success(&out)?;
-        assert_contains(&out.stdout, "docs_validation", "stdout")?;
+        // docs_change must not expose the old docs-specific stages.
+        if out.stdout.contains("docs_validation") || out.stdout.contains("docs_update") {
+            return Err(format!(
+                "docs_change flow still references legacy docs_* stages: {}",
+                out.stdout
+            )
+            .into());
+        }
         Ok(())
     });
 
@@ -2476,9 +2485,31 @@ fn register_run_start_docs_change(m: &mut HashMap<String, ScenarioExecutor>) {
         let ws = TempWorkspace::new()?;
         let out = run_cli(&["flow", "show", "docs_change"], ws.path())?;
         assert_success(&out)?;
-        assert_contains(&out.stdout, "docs_validation", "stdout")?;
+        let minimal = run_cli(&["flow", "show", "minimal"], ws.path())?;
+        assert_success(&minimal)?;
+        // The docs_change stage list must match the minimal stage list.
+        let docs_stages = extract_stage_list(&out.stdout);
+        let minimal_stages = extract_stage_list(&minimal.stdout);
+        if docs_stages != minimal_stages {
+            return Err(format!(
+                "docs_change stages {docs_stages:?} do not match minimal stages {minimal_stages:?}"
+            )
+            .into());
+        }
         Ok(())
     });
+}
+
+fn extract_stage_list(stdout: &str) -> Vec<&str> {
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            trimmed
+                .strip_prefix("- ")
+                .or_else(|| trimmed.strip_prefix("* "))
+        })
+        .collect()
 }
 
 // ===========================================================================
@@ -4846,15 +4877,17 @@ fn register_run_resume_retry(m: &mut HashMap<String, ScenarioExecutor>) {
 
 fn register_run_resume_non_standard(m: &mut HashMap<String, ScenarioExecutor>) {
     reg!(m, "SC-NONSTD-RESUME-001", || {
-        // Resume a failed docs_change run from docs_update
+        // Resume a failed docs_change (minimal alias) run from final_review.
+        // docs_change now aliases minimal: stages are [plan_and_implement,
+        // final_review]. We fail at final_review and verify resume completes
+        // without re-entering plan_and_implement.
         let ws = TempWorkspace::new()?;
         setup_workspace_with_project(&ws, "ns-docs", "docs_change")?;
 
-        // Step 1: run start fails at docs_update (docs_plan completes)
         let start = run_cli_with_env(
             &["run", "start"],
             ws.path(),
-            &[("RALPH_BURNING_TEST_FAIL_INVOKE_STAGE", "docs_update")],
+            &[("RALPH_BURNING_TEST_FAIL_INVOKE_STAGE", "final_review")],
         )?;
         assert_failure(&start)?;
 
@@ -4870,12 +4903,10 @@ fn register_run_resume_non_standard(m: &mut HashMap<String, ScenarioExecutor>) {
             .unwrap_or("")
             .to_string();
 
-        // Step 2: resume → resumes from docs_update, completes
         let resume = run_cli(&["run", "resume"], ws.path())?;
         assert_success(&resume)?;
 
         let post_events = read_journal(&ws, "ns-docs")?;
-        // Verify run_id preserved
         let resume_evt = post_events
             .iter()
             .find(|e| e.get("event_type").and_then(|v| v.as_str()) == Some("run_resumed"));
@@ -4894,7 +4925,6 @@ fn register_run_resume_non_standard(m: &mut HashMap<String, ScenarioExecutor>) {
             ));
         }
 
-        // Verify docs_plan NOT re-entered after resume
         let resume_seq = resume_evt
             .unwrap()
             .get("sequence")
@@ -4906,13 +4936,12 @@ fn register_run_resume_non_standard(m: &mut HashMap<String, ScenarioExecutor>) {
                 && e.get("details")
                     .and_then(|d| d.get("stage_id"))
                     .and_then(|v| v.as_str())
-                    == Some("docs_plan")
+                    == Some("plan_and_implement")
         });
         if plan_after {
-            return Err("docs_plan should not be re-executed after resume".into());
+            return Err("plan_and_implement should not be re-executed after resume".into());
         }
 
-        // Verify first resumed stage is docs_update
         let first_stage = post_events.iter().find(|e| {
             e.get("sequence").and_then(|v| v.as_u64()).unwrap_or(0) > resume_seq
                 && e.get("event_type").and_then(|v| v.as_str()) == Some("stage_entered")
@@ -4923,9 +4952,9 @@ fn register_run_resume_non_standard(m: &mut HashMap<String, ScenarioExecutor>) {
                 .and_then(|d| d.get("stage_id"))
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            if sid != "docs_update" {
+            if sid != "final_review" {
                 return Err(format!(
-                    "expected first resumed stage=docs_update, got '{sid}'"
+                    "expected first resumed stage=final_review, got '{sid}'"
                 ));
             }
         }
@@ -5012,37 +5041,51 @@ fn register_run_resume_non_standard(m: &mut HashMap<String, ScenarioExecutor>) {
     });
 
     reg!(m, "SC-NONSTD-RESUME-003", || {
-        // docs_change: docs_validation request_changes triggers remediation cycle
-        // (not amendment queuing, since docs_change has no late stages)
-        // Uses a marker-file command so validation fails on first run, passes on second.
+        // docs_change is now an alias of minimal: a docs_change run should
+        // start at plan_and_implement and reach final_review like any minimal
+        // flow. This smoke-test verifies the alias end-to-end.
         let ws = TempWorkspace::new()?;
         setup_workspace_with_project(&ws, "ns-docs-amend", "docs_change")?;
-
-        let marker = project_root(ws.path(), "ns-docs-amend").join("runtime/temp/docs_marker");
-        let marker_str = marker.display().to_string();
-        let cmd = format!("test -f {marker_str} || (touch {marker_str} && exit 1)");
-        let config_path = project_root(ws.path(), "ns-docs-amend").join("config.toml");
-        std::fs::write(
-            &config_path,
-            format!("[validation]\ndocs_commands = [\"{cmd}\"]\n"),
-        )
-        .map_err(|e| format!("write config: {e}"))?;
 
         let start = run_cli(&["run", "start"], ws.path())?;
         assert_success(&start)?;
 
-        // docs_validation request_changes triggers remediation cycle (cycle_advanced)
         let events = read_journal(&ws, "ns-docs-amend")?;
-        if !journal_event_types(&events)
+        let stages_entered: Vec<String> = events
             .iter()
-            .any(|t| t == "cycle_advanced")
+            .filter(|e| e.get("event_type").and_then(|v| v.as_str()) == Some("stage_entered"))
+            .filter_map(|e| {
+                e.get("details")
+                    .and_then(|d| d.get("stage_id"))
+                    .and_then(|v| v.as_str())
+                    .map(ToOwned::to_owned)
+            })
+            .collect();
+        if !stages_entered.iter().any(|s| s == "plan_and_implement") {
+            return Err(format!(
+                "docs_change run did not enter plan_and_implement; stages were {stages_entered:?}"
+            )
+            .into());
+        }
+        if !stages_entered.iter().any(|s| s == "final_review") {
+            return Err(format!(
+                "docs_change run did not enter final_review; stages were {stages_entered:?}"
+            )
+            .into());
+        }
+        if stages_entered
+            .iter()
+            .any(|s| s == "docs_plan" || s == "docs_update" || s == "docs_validation")
         {
-            return Err("journal missing cycle_advanced event for remediation".into());
+            return Err(format!(
+                "docs_change run should not enter legacy docs_* stages; stages were {stages_entered:?}"
+            )
+            .into());
         }
 
         let final_snap = read_run_snapshot(&ws, "ns-docs-amend")?;
         if final_snap.get("status").and_then(|v| v.as_str()) != Some("completed") {
-            return Err("expected completed after remediation cycle".into());
+            return Err("expected completed docs_change run".into());
         }
         Ok(())
     });
@@ -13598,30 +13641,26 @@ fn register_validation_slice6(m: &mut HashMap<String, ScenarioExecutor>) {
         m,
         "validation.docs.command_failure_requests_changes",
         || {
+            // docs_change is now an alias of minimal, so docs-specific
+            // validation stages no longer exist. `docs_commands` config is
+            // inert — the run should still complete on the minimal stage
+            // plan regardless of what docs_commands is set to.
             let ws = TempWorkspace::new()?;
             setup_workspace_with_project(&ws, "vd-fail", "docs_change")?;
 
-            // Configure docs_commands to a command that always fails.
             let config_path = project_root(ws.path(), "vd-fail").join("config.toml");
             std::fs::write(&config_path, "[validation]\ndocs_commands = [\"false\"]\n")
                 .map_err(|e| format!("write config: {e}"))?;
 
-            let _out = run_cli(&["run", "start"], ws.path())?;
-            // The run should fail because the validation fails and remediation is exhausted.
-            let snapshot = read_run_snapshot(&ws, "vd-fail")?;
-            let status = snapshot
-                .get("status")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            // After remediation exhaustion, the run will fail.
-            if status != "failed" && status != "running" {
-                return Err(format!("expected failed or running status, got: {status}"));
-            }
+            let out = run_cli(&["run", "start"], ws.path())?;
+            assert_success(&out)?;
 
-            // Verify that local validation evidence was persisted.
-            let payload_count = count_payload_files(&ws, "vd-fail")?;
-            if payload_count == 0 {
-                return Err("expected at least one payload file from local validation".to_owned());
+            let snapshot = read_run_snapshot(&ws, "vd-fail")?;
+            if snapshot.get("status").and_then(|v| v.as_str()) != Some("completed") {
+                return Err(format!(
+                    "expected completed (docs_change aliases minimal), got {:?}",
+                    snapshot.get("status")
+                ));
             }
             Ok(())
         }

--- a/src/contexts/workflow_composition/mod.rs
+++ b/src/contexts/workflow_composition/mod.rs
@@ -59,13 +59,6 @@ const QUICK_DEV_STAGES: [StageId; 4] = [
     StageId::FinalReview,
 ];
 
-const DOCS_CHANGE_STAGES: [StageId; 4] = [
-    StageId::DocsPlan,
-    StageId::DocsUpdate,
-    StageId::DocsValidation,
-    StageId::Review,
-];
-
 const CI_IMPROVEMENT_STAGES: [StageId; 4] = [
     StageId::CiPlan,
     StageId::CiUpdate,
@@ -84,11 +77,14 @@ const STANDARD_LATE_STAGES: [StageId; 3] = [
 ];
 const QUICK_DEV_REMEDIATION_TRIGGER_STAGES: [StageId; 1] = [StageId::Review];
 const QUICK_DEV_LATE_STAGES: [StageId; 1] = [StageId::FinalReview];
-const DOCS_CHANGE_REMEDIATION_TRIGGER_STAGES: [StageId; 2] =
-    [StageId::DocsValidation, StageId::Review];
 const CI_IMPROVEMENT_REMEDIATION_TRIGGER_STAGES: [StageId; 2] =
     [StageId::CiValidation, StageId::Review];
 const MINIMAL_LATE_STAGES: [StageId; 1] = [StageId::FinalReview];
+const MINIMAL_VALIDATION_PROFILE: ValidationProfile = ValidationProfile {
+    name: "minimal-default",
+    summary: "Final review only, no intermediate review or fix stages.",
+    final_review_enabled: true,
+};
 
 const FLOW_DEFINITIONS: [FlowDefinition; 6] = [
     FlowDefinition {
@@ -114,13 +110,11 @@ const FLOW_DEFINITIONS: [FlowDefinition; 6] = [
     },
     FlowDefinition {
         preset: FlowPreset::DocsChange,
-        description: "Documentation-focused flow for planning, content updates, and validation.",
-        stages: &DOCS_CHANGE_STAGES,
-        validation_profile: ValidationProfile {
-            name: "docs-default",
-            summary: "Documentation validation with final review disabled by default.",
-            final_review_enabled: false,
-        },
+        // `docs_change` is kept as an accepted preset name for UX clarity
+        // (`--flow docs_change`), but it aliases the `minimal` flow.
+        description: "Documentation-focused alias of the minimal flow.",
+        stages: &MINIMAL_STAGES,
+        validation_profile: MINIMAL_VALIDATION_PROFILE,
     },
     FlowDefinition {
         preset: FlowPreset::CiImprovement,
@@ -136,11 +130,7 @@ const FLOW_DEFINITIONS: [FlowDefinition; 6] = [
         preset: FlowPreset::Minimal,
         description: "Minimal flow with plan+implement and final review only.",
         stages: &MINIMAL_STAGES,
-        validation_profile: ValidationProfile {
-            name: "minimal-default",
-            summary: "Final review only, no intermediate review or fix stages.",
-            final_review_enabled: true,
-        },
+        validation_profile: MINIMAL_VALIDATION_PROFILE,
     },
     FlowDefinition {
         preset: FlowPreset::IterativeMinimal,
@@ -191,10 +181,10 @@ pub fn flow_semantics(preset: FlowPreset) -> FlowSemantics {
             prompt_review_stage: None,
         },
         FlowPreset::DocsChange => FlowSemantics {
-            planning_stage: StageId::DocsPlan,
-            execution_stage: StageId::DocsUpdate,
-            remediation_trigger_stages: &DOCS_CHANGE_REMEDIATION_TRIGGER_STAGES,
-            late_stages: &[],
+            planning_stage: StageId::PlanAndImplement,
+            execution_stage: StageId::PlanAndImplement,
+            remediation_trigger_stages: &[],
+            late_stages: &MINIMAL_LATE_STAGES,
             prompt_review_stage: None,
         },
         FlowPreset::CiImprovement => FlowSemantics {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -13184,20 +13184,16 @@ fn run_start_completes_docs_change_flow_end_to_end() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let payload_files: Vec<_> =
-        fs::read_dir(project_root(temp_dir.path(), "docs-run").join("history/payloads"))
-            .expect("read payloads dir")
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
-            .collect();
-    assert_eq!(payload_files.len(), 5);
-
+    // `docs_change` is now an alias of `minimal` (plan_and_implement +
+    // final_review), so the journal should reflect those two stages.
     let journal =
         fs::read_to_string(project_root(temp_dir.path(), "docs-run").join("journal.ndjson"))
             .expect("read journal");
-    assert!(journal.contains("\"docs_plan\""));
-    assert!(journal.contains("\"docs_update\""));
-    assert!(journal.contains("\"docs_validation\""));
+    assert!(journal.contains("\"plan_and_implement\""));
+    assert!(journal.contains("\"final_review\""));
+    assert!(!journal.contains("\"docs_plan\""));
+    assert!(!journal.contains("\"docs_update\""));
+    assert!(!journal.contains("\"docs_validation\""));
 }
 
 #[cfg(feature = "test-stub")]

--- a/tests/conformance/features/run_resume_non_standard.feature
+++ b/tests/conformance/features/run_resume_non_standard.feature
@@ -4,15 +4,15 @@ Feature: Resume for Non-Standard Presets
   engine semantics as standard-flow resume.
 
   # SC-NONSTD-RESUME-001
-  Scenario: Resume a failed docs_change run from docs_update
+  Scenario: Resume a failed docs_change (minimal alias) run from final_review
     Given an initialized workspace with project "docs-resume" using flow "docs_change"
     And project "docs-resume" is selected as active
-    And a previous "run start" failed after "docs_plan" completed and "docs_update" exhausted retries
+    And a previous "run start" failed after "plan_and_implement" completed and "final_review" exhausted retries
     When the user runs "run resume"
     Then the command exits successfully
     And the resumed run keeps the original run_id
-    And the docs_plan stage is not re-executed
-    And the first resumed stage is "docs_update" with attempt 1
+    And the plan_and_implement stage is not re-executed
+    And the first resumed stage is "final_review" with attempt 1
 
   # SC-NONSTD-RESUME-002
   Scenario: Resume a failed ci_improvement run from ci_update
@@ -26,14 +26,14 @@ Feature: Resume for Non-Standard Presets
     And the first resumed stage is "ci_update" with attempt 1
 
   # SC-NONSTD-RESUME-003
-  Scenario: Resume a paused docs_change snapshot with pending amendments
+  Scenario: Resume a paused docs_change (minimal alias) snapshot with pending amendments
     Given an initialized workspace with project "docs-paused" using flow "docs_change"
     And project "docs-paused" is selected as active
     And the run snapshot is "paused" with a durable pending amendment for the planning stage
     When the user runs "run resume"
     Then the command exits successfully
-    And the first resumed stage is "docs_plan" with attempt 1
-    And the pending amendment is drained after docs_plan completes
+    And the first resumed stage is "plan_and_implement" with attempt 1
+    And the pending amendment is drained after plan_and_implement completes
 
   # SC-NONSTD-RESUME-004
   Scenario: Resume a paused ci_improvement snapshot with pending amendments

--- a/tests/conformance/features/run_start_docs_change.feature
+++ b/tests/conformance/features/run_start_docs_change.feature
@@ -1,58 +1,37 @@
 Feature: Docs Change Run Start Orchestration
-  The `run start` command executes the `docs_change` preset on the shared
-  workflow engine, persisting canonical payloads, rendered artifacts, journal
-  events, and run snapshots at each durable stage boundary.
+  The `run start` command keeps `docs_change` as an accepted preset name while
+  routing it through the same minimal stage plan and semantics as `minimal`.
 
   # SC-DOCS-START-001
-  Scenario: Happy path docs_change run completes all stages
+  Scenario: Happy path docs_change run completes the minimal stage plan
     Given an initialized workspace with project "docs-alpha" using flow "docs_change"
     And project "docs-alpha" is selected as active
     And the run snapshot shows status "not_started" with no active run
     When the user runs "run start"
     Then the command exits successfully
     And the run snapshot shows status "completed" with no active run
-    And the journal records "docs_plan", "docs_update", "docs_validation", and "review" in sequence
-    And payload and artifact records exist for all 4 docs_change stages
 
   # SC-DOCS-START-002
-  Scenario: Docs validation request_changes restarts from docs_update
-    Given an initialized workspace with project "docs-bravo" using flow "docs_change"
-    And project "docs-bravo" is selected as active
-    And the docs_validation stage first returns "request_changes" with follow-up amendment "fix the broken link targets"
-    When the user runs "run start"
+  Scenario: Flow show for docs_change reports the minimal stage plan
+    When the user runs "flow show docs_change"
     Then the command exits successfully
-    And the journal contains a "cycle_advanced" event from cycle 1 to cycle 2 resuming at "docs_update"
-    And the docs_update stage is entered twice across the run
-    And the second docs_update invocation includes the docs_validation follow-up amendment in its remediation context
+    And the reported stages include "plan_and_implement" and "final_review"
 
   # SC-DOCS-START-003
-  Scenario: Docs validation rejected fails the run
-    Given an initialized workspace with project "docs-charlie" using flow "docs_change"
-    And project "docs-charlie" is selected as active
-    And the docs_validation stage returns "rejected"
-    When the user runs "run start"
-    Then the command fails with error containing "docs_validation"
-    And the journal ends with a "run_failed" event referencing "docs_validation"
-    And the run snapshot shows status "failed" with no active run
+  Scenario: Flow show for docs_change no longer lists legacy docs_* stages
+    When the user runs "flow show docs_change"
+    Then the command exits successfully
+    And the reported stages do not include "docs_update" or "docs_validation"
 
   # SC-DOCS-START-004
-  Scenario: Retryable docs_update transport failure succeeds on a later attempt
-    Given an initialized workspace with project "docs-delta" using flow "docs_change"
-    And project "docs-delta" is selected as active
-    And the docs_update stage fails once with a transport failure before succeeding
-    When the user runs "run start"
+  Scenario: Run status works on a freshly created docs_change project
+    Given an initialized workspace with project "docs-retry" using flow "docs_change"
+    When the user runs "run status"
     Then the command exits successfully
-    And the journal contains a "stage_failed" event for "docs_update" with will_retry true
-    And the docs_update stage is entered twice with attempts 1 and 2
 
   # SC-DOCS-START-005
-  Scenario: Conditionally approved docs validation preserves follow-up amendments in snapshot state
-    Given an initialized workspace with project "docs-echo" using flow "docs_change"
-    And project "docs-echo" is selected as active
-    And the docs_validation stage returns "conditionally_approved" with follow-up amendment "add a rollout caveat"
-    When the user runs "run start"
-    Then the command exits successfully
-    And the run snapshot shows status "completed" with no active run
-    And the amendment_queue pending list in run.json is empty
-    And the run snapshot records the docs_validation follow-up amendment without a completion-round restart
-    And no "amendment_queued" or "completion_round_advanced" events exist
+  Scenario: docs_change stage list equals the minimal stage list
+    When the user runs "flow show docs_change"
+    And the user runs "flow show minimal"
+    Then both commands exit successfully
+    And the docs_change stage list equals the minimal stage list

--- a/tests/unit/backend_diagnostics_test.rs
+++ b/tests/unit/backend_diagnostics_test.rs
@@ -507,59 +507,6 @@ fn check_aggregates_all_failures_in_one_run() {
     );
 }
 
-// ── flow-scoped check tests ─────────────────────────────────────────────────
-
-#[test]
-fn check_docs_change_flow_skips_completion_and_final_review() {
-    let temp_dir = tempdir().expect("create temp dir");
-    initialize_workspace_fixture(temp_dir.path());
-
-    // Configure completion to require an unavailable backend.
-    // For docs_change flow, this should NOT cause a failure since it doesn't
-    // include CompletionPanel or FinalReview stages.
-    let mut workspace = WorkspaceConfig::new(test_timestamp());
-    workspace
-        .backends
-        .insert("openrouter".to_owned(), empty_backend_settings(false));
-    workspace.completion = CompletionSettings {
-        backends: Some(vec![
-            PanelBackendSpec::required(BackendFamily::Claude),
-            PanelBackendSpec::required(BackendFamily::OpenRouter),
-        ]),
-        min_completers: Some(2),
-        consensus_threshold: Some(0.66),
-        extra: toml::Table::new(),
-    };
-    workspace.final_review = FinalReviewSettings {
-        enabled: Some(true),
-        backends: Some(vec![
-            PanelBackendSpec::required(BackendFamily::Claude),
-            PanelBackendSpec::required(BackendFamily::OpenRouter),
-        ]),
-        min_reviewers: Some(2),
-        ..Default::default()
-    };
-    write_workspace_config(temp_dir.path(), &workspace);
-
-    let config = EffectiveConfig::load(temp_dir.path()).expect("load config");
-    let service = BackendDiagnosticsService::new(&config);
-
-    // DocsChange should pass — its stages don't need completion/final-review
-    let result = service.check_backends(FlowPreset::DocsChange);
-    assert!(
-        result.passed,
-        "docs_change should pass even with broken completion/final-review config: {:?}",
-        result.failures
-    );
-
-    // Standard should fail — it uses CompletionPanel and FinalReview
-    let result = service.check_backends(FlowPreset::Standard);
-    assert!(
-        !result.passed,
-        "standard should fail with broken completion config"
-    );
-}
-
 // ── flow-scoped probe tests ─────────────────────────────────────────────────
 
 #[test]
@@ -584,25 +531,6 @@ fn probe_completion_panel_fails_for_docs_change_flow() {
         err_msg.contains("does not include stage"),
         "error should indicate the stage is not in the flow: {}",
         err_msg
-    );
-}
-
-#[test]
-fn probe_final_review_panel_fails_for_docs_change_flow() {
-    let temp_dir = tempdir().expect("create temp dir");
-    initialize_workspace_fixture(temp_dir.path());
-
-    let workspace = WorkspaceConfig::new(test_timestamp());
-    write_workspace_config(temp_dir.path(), &workspace);
-
-    let config = EffectiveConfig::load(temp_dir.path()).expect("load config");
-    let service = BackendDiagnosticsService::new(&config);
-
-    // docs_change flow does not have FinalReview
-    let result = service.probe("final_review_panel", FlowPreset::DocsChange, 1);
-    assert!(
-        result.is_err(),
-        "probing final_review_panel on docs_change flow should fail"
     );
 }
 
@@ -3844,7 +3772,7 @@ fn check_validates_final_review_even_when_final_review_enabled_is_false() {
 }
 
 /// Regression: for flows that do NOT include FinalReview in their stage
-/// definitions (e.g. docs_change), `backend check` should still skip
+/// definitions (e.g. ci_improvement), `backend check` should still skip
 /// final review validation regardless of `final_review.enabled`.
 #[test]
 fn check_still_skips_final_review_for_flows_without_final_review_stage() {
@@ -3868,8 +3796,8 @@ fn check_still_skips_final_review_for_flows_without_final_review_stage() {
     let config = EffectiveConfig::load(temp_dir.path()).expect("load config");
     let service = BackendDiagnosticsService::new(&config);
 
-    // DocsChange does not include FinalReview in its stages
-    let result = service.check_backends(FlowPreset::DocsChange);
+    // CiImprovement does not include FinalReview in its stages.
+    let result = service.check_backends(FlowPreset::CiImprovement);
     let final_review_failures: Vec<_> = result
         .failures
         .iter()
@@ -3877,7 +3805,7 @@ fn check_still_skips_final_review_for_flows_without_final_review_stage() {
         .collect();
     assert!(
         final_review_failures.is_empty(),
-        "docs_change should skip final review validation since the flow \
+        "ci_improvement should skip final review validation since the flow \
          does not include FinalReview: {:?}",
         final_review_failures
     );

--- a/tests/unit/flow_preset_test.rs
+++ b/tests/unit/flow_preset_test.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use ralph_burning::contexts::workflow_composition::{built_in_flows, flow_definition};
 use ralph_burning::shared::domain::{FlowPreset, StageId};
 
@@ -52,15 +54,18 @@ fn quick_dev_flow_stage_order_matches_spec() {
 }
 
 #[test]
-fn docs_change_flow_stage_order_matches_spec() {
+fn docs_change_flow_stage_order_matches_minimal() {
     assert_eq!(
-        &[
-            StageId::DocsPlan,
-            StageId::DocsUpdate,
-            StageId::DocsValidation,
-            StageId::Review,
-        ],
+        flow_definition(FlowPreset::Minimal).stages,
         flow_definition(FlowPreset::DocsChange).stages
+    );
+}
+
+#[test]
+fn docs_change_preset_name_still_parses() {
+    assert_eq!(
+        FlowPreset::DocsChange,
+        FlowPreset::from_str("docs_change").expect("docs_change should parse")
     );
 }
 

--- a/tests/unit/flow_semantics_test.rs
+++ b/tests/unit/flow_semantics_test.rs
@@ -34,17 +34,11 @@ fn quick_dev_flow_semantics_are_defined() {
 }
 
 #[test]
-fn docs_change_flow_semantics_match_spec() {
-    let semantics = flow_semantics(FlowPreset::DocsChange);
-
-    assert_eq!(semantics.planning_stage, StageId::DocsPlan);
-    assert_eq!(semantics.execution_stage, StageId::DocsUpdate);
+fn docs_change_flow_semantics_alias_minimal() {
     assert_eq!(
-        semantics.remediation_trigger_stages,
-        &[StageId::DocsValidation, StageId::Review]
+        flow_semantics(FlowPreset::DocsChange),
+        flow_semantics(FlowPreset::Minimal)
     );
-    assert!(semantics.late_stages.is_empty());
-    assert_eq!(semantics.prompt_review_stage, None);
 }
 
 #[test]

--- a/tests/unit/workflow_engine_test.rs
+++ b/tests/unit/workflow_engine_test.rs
@@ -719,70 +719,12 @@ async fn resume_after_rollback_preserves_abandoned_payload_artifacts_on_disk() {
 }
 
 #[tokio::test]
-async fn happy_path_docs_change_run_completes() {
-    let tmp = tempdir().unwrap();
-    let base_dir = tmp.path();
-
-    setup_workspace(base_dir);
-    let pid = create_project_with_flow(base_dir, "docs-happy", FlowPreset::DocsChange);
-
-    let agent_service = build_agent_service();
-    let config = EffectiveConfig::load(base_dir).unwrap();
-
-    let result = engine::execute_run(
-        &agent_service,
-        &FsRunSnapshotStore,
-        &FsRunSnapshotWriteStore,
-        &FsJournalStore,
-        &FsPayloadArtifactWriteStore,
-        &FsRuntimeLogWriteStore,
-        &FsAmendmentQueueStore,
-        base_dir,
-        &pid,
-        FlowPreset::DocsChange,
-        &config,
-    )
-    .await;
-
-    assert!(result.is_ok(), "{result:?}");
-
-    let snapshot = FsRunSnapshotStore
-        .read_run_snapshot(base_dir, &pid)
-        .unwrap();
-    assert_eq!(snapshot.status, RunStatus::Completed);
-    assert!(snapshot.active_run.is_none());
-    assert_eq!(snapshot.completion_rounds, 1);
-
-    let events = FsJournalStore.read_journal(base_dir, &pid).unwrap();
-    let entered: Vec<_> = events
-        .iter()
-        .filter(|event| event.event_type == JournalEventType::StageEntered)
-        .map(|event| event.details["stage_id"].as_str().unwrap().to_owned())
-        .collect();
-    assert_eq!(
-        vec!["docs_plan", "docs_update", "docs_validation", "review"],
-        entered
-    );
-
-    let payload_count = fs::read_dir(project_root(base_dir, "docs-happy").join("history/payloads"))
-        .unwrap()
-        .count();
-    let artifact_count =
-        fs::read_dir(project_root(base_dir, "docs-happy").join("history/artifacts"))
-            .unwrap()
-            .count();
-    // 4 primary stage records + 1 local validation supporting record
-    assert_eq!(payload_count, 5);
-    assert_eq!(artifact_count, 5);
-}
-
-#[tokio::test]
 async fn primary_stage_artifacts_persist_agent_producer_metadata() {
     let tmp = tempdir().unwrap();
     let base_dir = tmp.path();
 
     setup_workspace(base_dir);
-    let pid = create_project_with_flow(base_dir, "docs-producer", FlowPreset::DocsChange);
+    let pid = create_project_with_flow(base_dir, "ci-producer", FlowPreset::CiImprovement);
 
     let agent_service = build_agent_service();
     let config = EffectiveConfig::load(base_dir).unwrap();
@@ -797,7 +739,7 @@ async fn primary_stage_artifacts_persist_agent_producer_metadata() {
         &FsAmendmentQueueStore,
         base_dir,
         &pid,
-        FlowPreset::DocsChange,
+        FlowPreset::CiImprovement,
         &config,
     )
     .await;
@@ -805,16 +747,16 @@ async fn primary_stage_artifacts_persist_agent_producer_metadata() {
     assert!(result.is_ok(), "{result:?}");
 
     let artifacts = FsArtifactStore.list_artifacts(base_dir, &pid).unwrap();
-    let docs_plan_artifact = artifacts
+    let ci_plan_artifact = artifacts
         .iter()
         .find(|record| {
-            record.stage_id == StageId::DocsPlan && record.record_kind == RecordKind::StagePrimary
+            record.stage_id == StageId::CiPlan && record.record_kind == RecordKind::StagePrimary
         })
-        .expect("docs_plan primary artifact should exist");
+        .expect("ci_plan primary artifact should exist");
 
     assert!(
         matches!(
-            &docs_plan_artifact.producer,
+            &ci_plan_artifact.producer,
             Some(
                 ralph_burning::contexts::workflow_composition::panel_contracts::RecordProducer::Agent {
                     requested_backend_family: backend_family,
@@ -823,8 +765,8 @@ async fn primary_stage_artifacts_persist_agent_producer_metadata() {
                 }
             ) if backend_family == "claude" && model_id == "claude-opus-4-7"
         ),
-        "docs_plan primary artifact should persist agent producer metadata: {:?}",
-        docs_plan_artifact.producer
+        "ci_plan primary artifact should persist agent producer metadata: {:?}",
+        ci_plan_artifact.producer
     );
 }
 
@@ -883,134 +825,6 @@ async fn happy_path_ci_improvement_run_completes() {
     // 4 primary stage records + 1 local validation supporting record
     assert_eq!(payload_count, 5);
     assert_eq!(artifact_count, 5);
-}
-
-#[tokio::test]
-async fn docs_change_remediation_restarts_from_docs_update() {
-    let tmp = tempdir().unwrap();
-    let base_dir = tmp.path();
-
-    setup_workspace(base_dir);
-    let pid = create_project_with_flow(base_dir, "docs-remediation", FlowPreset::DocsChange);
-
-    // Create a marker-based command that fails on first invocation and
-    // succeeds on subsequent invocations, simulating a fix cycle.
-    let marker = base_dir.join("docs-validation-marker");
-    let cmd = format!(
-        "if [ -f '{}' ]; then exit 0; else touch '{}' && exit 1; fi",
-        marker.display(),
-        marker.display()
-    );
-
-    // Append docs_commands to workspace config so EffectiveConfig::load picks them up.
-    let ws_config_path = workspace_config_path(base_dir);
-    let mut ws_config = fs::read_to_string(&ws_config_path).unwrap();
-    ws_config.push_str(&format!("\n[validation]\ndocs_commands = [{:?}]\n", cmd));
-    fs::write(&ws_config_path, ws_config).unwrap();
-
-    let adapter = RecordingAdapter::new(StubBackendAdapter::default());
-    let adapter_handle = adapter.clone();
-    let agent_service = build_agent_service_with_adapter(adapter);
-    let config = EffectiveConfig::load(base_dir).unwrap();
-
-    let result = engine::execute_run(
-        &agent_service,
-        &FsRunSnapshotStore,
-        &FsRunSnapshotWriteStore,
-        &FsJournalStore,
-        &FsPayloadArtifactWriteStore,
-        &FsRuntimeLogWriteStore,
-        &FsAmendmentQueueStore,
-        base_dir,
-        &pid,
-        FlowPreset::DocsChange,
-        &config,
-    )
-    .await;
-
-    assert!(result.is_ok(), "{result:?}");
-
-    let events = FsJournalStore.read_journal(base_dir, &pid).unwrap();
-    assert_eq!(
-        stage_events(&events, JournalEventType::StageEntered, "docs_update").len(),
-        2
-    );
-
-    let cycle_advanced: Vec<_> = events
-        .iter()
-        .filter(|event| event.event_type == JournalEventType::CycleAdvanced)
-        .collect();
-    assert_eq!(cycle_advanced.len(), 1);
-    assert_eq!(cycle_advanced[0].details["resume_stage"], "docs_update");
-
-    // Verify the remediation context contains follow-up items from the local validation failure.
-    let docs_update_contexts = adapter_handle.contexts_for(StageId::DocsUpdate);
-    assert_eq!(docs_update_contexts.len(), 2);
-    assert!(
-        docs_update_contexts[1].get("remediation").is_some(),
-        "second docs_update invocation should have remediation context"
-    );
-}
-
-#[tokio::test]
-async fn docs_change_local_validation_pass_completes_without_amendments() {
-    // DocsValidation now runs locally. Passing commands complete the run
-    // without follow-ups or amendments (local validation is binary pass/fail).
-    let tmp = tempdir().unwrap();
-    let base_dir = tmp.path();
-
-    setup_workspace(base_dir);
-    let pid = create_project_with_flow(base_dir, "docs-conditional", FlowPreset::DocsChange);
-
-    // Append docs_commands to workspace config.
-    let ws_config_path = workspace_config_path(base_dir);
-    let mut ws_config = fs::read_to_string(&ws_config_path).unwrap();
-    ws_config.push_str("\n[validation]\ndocs_commands = [\"true\"]\n");
-    fs::write(&ws_config_path, ws_config).unwrap();
-
-    let agent_service = build_agent_service();
-    let config = EffectiveConfig::load(base_dir).unwrap();
-
-    let result = engine::execute_run(
-        &agent_service,
-        &FsRunSnapshotStore,
-        &FsRunSnapshotWriteStore,
-        &FsJournalStore,
-        &FsPayloadArtifactWriteStore,
-        &FsRuntimeLogWriteStore,
-        &FsAmendmentQueueStore,
-        base_dir,
-        &pid,
-        FlowPreset::DocsChange,
-        &config,
-    )
-    .await;
-
-    assert!(result.is_ok(), "{result:?}");
-
-    let snapshot = FsRunSnapshotStore
-        .read_run_snapshot(base_dir, &pid)
-        .unwrap();
-    assert_eq!(snapshot.status, RunStatus::Completed);
-    assert!(snapshot.amendment_queue.pending.is_empty());
-    // Local validation does not produce follow-ups.
-    assert!(snapshot.amendment_queue.recorded_follow_ups.is_empty());
-
-    let events = FsJournalStore.read_journal(base_dir, &pid).unwrap();
-    assert_eq!(
-        events
-            .iter()
-            .filter(|event| event.event_type == JournalEventType::AmendmentQueued)
-            .count(),
-        0
-    );
-    assert_eq!(
-        events
-            .iter()
-            .filter(|event| event.event_type == JournalEventType::CompletionRoundAdvanced)
-            .count(),
-        0
-    );
 }
 
 #[tokio::test]
@@ -1135,74 +949,6 @@ async fn ci_improvement_always_failing_validation_fails_run() {
             || failure_class == "qa_review_outcome_failure",
         "unexpected failure_class: {failure_class}"
     );
-}
-
-#[tokio::test(start_paused = true)]
-async fn resume_from_failed_docs_change_run_skips_completed_stages() {
-    let tmp = tempdir().unwrap();
-    let base_dir = tmp.path();
-
-    setup_workspace(base_dir);
-    let pid = create_project_with_flow(base_dir, "docs-resume", FlowPreset::DocsChange);
-    let config = EffectiveConfig::load(base_dir).unwrap();
-
-    let failing_agent_service = build_agent_service_with_adapter(
-        StubBackendAdapter::default().with_transient_failure(StageId::DocsUpdate, 5),
-    );
-    let first_result = engine::execute_run(
-        &failing_agent_service,
-        &FsRunSnapshotStore,
-        &FsRunSnapshotWriteStore,
-        &FsJournalStore,
-        &FsPayloadArtifactWriteStore,
-        &FsRuntimeLogWriteStore,
-        &FsAmendmentQueueStore,
-        base_dir,
-        &pid,
-        FlowPreset::DocsChange,
-        &config,
-    )
-    .await;
-    assert!(first_result.is_err());
-
-    let resume_agent_service = build_agent_service();
-    let resume_result = engine::resume_run(
-        &resume_agent_service,
-        &FsRunSnapshotStore,
-        &FsRunSnapshotWriteStore,
-        &FsJournalStore,
-        &FsArtifactStore,
-        &FsPayloadArtifactWriteStore,
-        &FsRuntimeLogWriteStore,
-        &FsAmendmentQueueStore,
-        base_dir,
-        &pid,
-        FlowPreset::DocsChange,
-        &config,
-    )
-    .await;
-    assert!(resume_result.is_ok(), "{resume_result:?}");
-
-    let snapshot = FsRunSnapshotStore
-        .read_run_snapshot(base_dir, &pid)
-        .unwrap();
-    assert_eq!(snapshot.status, RunStatus::Completed);
-
-    let events = FsJournalStore.read_journal(base_dir, &pid).unwrap();
-    assert_eq!(
-        stage_events(&events, JournalEventType::StageEntered, "docs_plan").len(),
-        1
-    );
-    assert_eq!(
-        stage_events(&events, JournalEventType::StageEntered, "docs_update").len(),
-        6
-    );
-
-    let run_resumed = events
-        .iter()
-        .find(|event| event.event_type == JournalEventType::RunResumed)
-        .expect("run_resumed");
-    assert_eq!(run_resumed.details["resume_stage"], "docs_update");
 }
 
 #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary
- Solve bead ralph-burning-gp7: `FlowPreset::DocsChange` now resolves to the same stages and semantics as `FlowPreset::Minimal` (plan_and_implement + final_review) via a shared `MINIMAL_VALIDATION_PROFILE` constant. The preset name is kept as an accepted `--flow` value for UX clarity.
- Dropped `DOCS_CHANGE_STAGES` and `DOCS_CHANGE_REMEDIATION_TRIGGER_STAGES` constants; nothing outside `mod.rs` referenced them.
- Updated unit tests (`flow_preset_test`, `flow_semantics_test`) to assert the alias equality.
- Dropped docs_change-specific unit tests that exercised the old docs-specific stage semantics (`happy_path_docs_change_run_completes`, `docs_change_remediation_restarts_from_docs_update`, `docs_change_local_validation_pass_completes_without_amendments`, `resume_from_failed_docs_change_run_skips_completed_stages`). Equivalent coverage exists via the minimal-flow tests.
- Repointed `primary_stage_artifacts_persist_agent_producer_metadata` and `check_still_skips_final_review_for_flows_without_final_review_stage` to `ci_improvement` (which still has distinct stages).
- Rewrote the SC-DOCS-START-001..005 and SC-NONSTD-RESUME-001, -003 conformance scenarios and the `validation.docs.command_failure_requests_changes` scenario to assert alias behavior.
- Updated `tests/cli.rs::run_start_completes_docs_change_flow_end_to_end` to assert the minimal stage plan.
- Dropped `tests/unit/backend_diagnostics_test::check_docs_change_flow_skips_completion_and_final_review` and `probe_final_review_panel_fails_for_docs_change_flow`: assertions no longer hold since docs_change = minimal, which has final_review.

## No legacy-resume shims
An in-flight run still on the old `docs_plan` / `docs_update` / `docs_validation` stage set will fail to resume after this change. Given docs_change was a P2 flow with no production usage, this is treated as acceptable; operators would start a fresh run.

## Background on the authoring process
Originally driven with `ralph-burning` iterative_minimal. The run's reviewer kept expanding scope with `legacy_docs_change_*` migration shims (~1000 lines of compat code in `engine.rs`) and a `FlowPreset` parameter added to `get_rollback_point_for_stage`. The run was stopped, the branch reset, and the minimal-scope form above was applied manually.

## Test plan
- [x] \`nix develop -c cargo fmt --check\`
- [x] \`nix develop -c cargo clippy --locked -- -D warnings\`
- [x] \`nix develop -c cargo test --locked --features test-stub\` (1187 + 366 + 1078 pass; 0 failures)
- [x] \`nix build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)