### PR TITLE
chore(config): bump codex default models from gpt-5.4 to gpt-5.5

### DIFF
--- a/src/adapters/process_backend.rs
+++ b/src/adapters/process_backend.rs
@@ -2783,10 +2783,10 @@ mod tests {
     fn codex_model_suffix_parses_reasoning_effort_and_fast_mode() {
         assert_eq!(
             ProcessBackendAdapter::codex_model_reasoning_effort_and_fast(
-                "gpt-5.4-xhigh-fast",
+                "gpt-5.5-xhigh-fast",
                 true
             ),
-            ("gpt-5.4", Some("xhigh"), true)
+            ("gpt-5.5", Some("xhigh"), true)
         );
         assert_eq!(
             ProcessBackendAdapter::codex_model_reasoning_effort_and_fast(
@@ -2796,12 +2796,12 @@ mod tests {
             ("gpt-5.3-codex-spark", Some("xhigh"), true)
         );
         assert_eq!(
-            ProcessBackendAdapter::codex_model_reasoning_effort_and_fast("gpt-5.4-fast", true),
-            ("gpt-5.4", None, true)
+            ProcessBackendAdapter::codex_model_reasoning_effort_and_fast("gpt-5.5-fast", true),
+            ("gpt-5.5", None, true)
         );
         assert_eq!(
-            ProcessBackendAdapter::codex_model_reasoning_effort_and_fast("gpt-5.4-xhigh", true),
-            ("gpt-5.4", Some("xhigh"), false)
+            ProcessBackendAdapter::codex_model_reasoning_effort_and_fast("gpt-5.5-xhigh", true),
+            ("gpt-5.5", Some("xhigh"), false)
         );
         assert_eq!(
             ProcessBackendAdapter::codex_model_reasoning_effort_and_fast(

--- a/src/contexts/conformance_spec/scenarios.rs
+++ b/src/contexts/conformance_spec/scenarios.rs
@@ -11772,7 +11772,7 @@ fn register_workflow_panels(m: &mut HashMap<String, ScenarioExecutor>) {
             }
 
             // Change implementer backend config to force drift. Default
-            // implementer for cycle 1 is codex/gpt-5.4-high, so switching
+            // implementer for cycle 1 is codex/gpt-5.5-high, so switching
             // to claude produces an actual target change.
             let ws_toml = workspace_config_path(ws.path());
             let content = std::fs::read_to_string(&ws_toml).map_err(|e| format!("read: {e}"))?;
@@ -11800,7 +11800,7 @@ fn register_workflow_panels(m: &mut HashMap<String, ScenarioExecutor>) {
             }
 
             // Check journal for durable_warning event indicating drift detection.
-            // Changing implementer_backend from the default codex/gpt-5.4-high
+            // Changing implementer_backend from the default codex/gpt-5.5-high
             // to claude changes the resolved target, so drift MUST fire.
             let events = read_journal(&ws, "drift-impl")?;
             let warning_event = events

--- a/src/contexts/workflow_composition/engine.rs
+++ b/src/contexts/workflow_composition/engine.rs
@@ -10707,7 +10707,7 @@ mod tests {
             backend: "codex".to_owned(),
             contract_id: "final_review:reviewer".to_owned(),
             failure_class: FailureClass::TransportFailure,
-            details: "reviewer-1 (codex/gpt-5.4-xhigh) exhausted 5 transient retries: ERROR: stream disconnected before completion".to_owned(),
+            details: "reviewer-1 (codex/gpt-5.5-xhigh) exhausted 5 transient retries: ERROR: stream disconnected before completion".to_owned(),
         };
         let cursor = StageCursor::new(StageId::FinalReview, 1, 1, 1).expect("cursor");
 
@@ -10725,7 +10725,7 @@ mod tests {
         let retry_policy = RetryPolicy::default_policy().with_no_backoff();
         let error = AppError::BackendUnavailable {
             backend: "codex".to_owned(),
-            details: "reviewer-1 (codex/gpt-5.4-xhigh) exhausted 5 transient retries: stream disconnected before completion".to_owned(),
+            details: "reviewer-1 (codex/gpt-5.5-xhigh) exhausted 5 transient retries: stream disconnected before completion".to_owned(),
             failure_class: Some(FailureClass::TransportFailure),
         };
         let cursor = StageCursor::new(StageId::FinalReview, 1, 1, 1).expect("cursor");
@@ -11086,7 +11086,7 @@ mod tests {
 
         let run_id = RunId::new("run-iter-terminal").expect("run id");
         let cursor = StageCursor::new(StageId::PlanAndImplement, 1, 1, 1).expect("cursor");
-        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4");
+        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5");
         let stage_entry = StagePlan {
             stage_id: StageId::PlanAndImplement,
             role: role_for_stage(StageId::PlanAndImplement),
@@ -11206,7 +11206,7 @@ mod tests {
             stage_id: StageId::PlanAndImplement,
             role: role_for_stage(StageId::PlanAndImplement),
             contract: contracts::contract_for_stage(StageId::PlanAndImplement),
-            target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4"),
+            target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5"),
         };
         let project_root = FileSystem::project_root(temp_dir.path(), &project_id);
         let invocation_id =
@@ -11231,7 +11231,7 @@ mod tests {
         });
         let producer = RecordProducer::Agent {
             requested_backend_family: "codex".to_owned(),
-            requested_model_id: "gpt-5.4".to_owned(),
+            requested_model_id: "gpt-5.5".to_owned(),
             actual_backend_family: "openrouter".to_owned(),
             actual_model_id: "openai/gpt-4.1".to_owned(),
         };
@@ -11308,7 +11308,7 @@ mod tests {
 
         let run_id = RunId::new("run-iter-terminal-raw-fallback").expect("run id");
         let cursor = StageCursor::new(StageId::PlanAndImplement, 1, 1, 1).expect("cursor");
-        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4");
+        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5");
         let stage_entry = StagePlan {
             stage_id: StageId::PlanAndImplement,
             role: role_for_stage(StageId::PlanAndImplement),
@@ -11378,9 +11378,9 @@ mod tests {
                     producer,
                     RecordProducer::Agent {
                         requested_backend_family: "codex".to_owned(),
-                        requested_model_id: "gpt-5.4".to_owned(),
+                        requested_model_id: "gpt-5.5".to_owned(),
                         actual_backend_family: "codex".to_owned(),
-                        actual_model_id: "gpt-5.4".to_owned(),
+                        actual_model_id: "gpt-5.5".to_owned(),
                     }
                 );
             }
@@ -11530,7 +11530,7 @@ mod tests {
 
         let run_id = RunId::new("run-iter-terminal-codex-raw").expect("run id");
         let cursor = StageCursor::new(StageId::PlanAndImplement, 1, 1, 1).expect("cursor");
-        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4");
+        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5");
         let stage_entry = StagePlan {
             stage_id: StageId::PlanAndImplement,
             role: role_for_stage(StageId::PlanAndImplement),
@@ -11605,9 +11605,9 @@ mod tests {
                     producer,
                     RecordProducer::Agent {
                         requested_backend_family: "codex".to_owned(),
-                        requested_model_id: "gpt-5.4".to_owned(),
+                        requested_model_id: "gpt-5.5".to_owned(),
                         actual_backend_family: "codex".to_owned(),
-                        actual_model_id: "gpt-5.4".to_owned(),
+                        actual_model_id: "gpt-5.5".to_owned(),
                     }
                 );
             }
@@ -11642,7 +11642,7 @@ mod tests {
         let old_run_id = RunId::new("run-iter-old").expect("old run id");
         let run_id = RunId::new("run-iter-new").expect("new run id");
         let cursor = StageCursor::new(StageId::PlanAndImplement, 1, 1, 1).expect("cursor");
-        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4");
+        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5");
         let stage_entry = StagePlan {
             stage_id: StageId::PlanAndImplement,
             role: role_for_stage(StageId::PlanAndImplement),
@@ -11776,7 +11776,7 @@ mod tests {
 
         let run_id = RunId::new("run-iter-terminal-rewind").expect("run id");
         let cursor = StageCursor::new(StageId::PlanAndImplement, 1, 1, 1).expect("cursor");
-        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4");
+        let resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5");
         let stage_entry = StagePlan {
             stage_id: StageId::PlanAndImplement,
             role: role_for_stage(StageId::PlanAndImplement),
@@ -11819,7 +11819,7 @@ mod tests {
             &mut seq,
             &stage_entry,
             &cursor,
-            &ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4"),
+            &ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5"),
             2,
             1,
             1,

--- a/src/contexts/workflow_composition/final_review.rs
+++ b/src/contexts/workflow_composition/final_review.rs
@@ -2906,11 +2906,11 @@ mod tests {
             backend: "codex".to_owned(),
             contract_id: "final_review:reviewer".to_owned(),
             failure_class: FailureClass::TransportFailure,
-            details: "reviewer-1 (codex/gpt-5.4-xhigh) exhausted 5 transient retries: ERROR: stream disconnected before completion".to_owned(),
+            details: "reviewer-1 (codex/gpt-5.5-xhigh) exhausted 5 transient retries: ERROR: stream disconnected before completion".to_owned(),
         };
         let availability_exhaustion = AppError::BackendUnavailable {
             backend: "codex".to_owned(),
-            details: "reviewer-1 (codex/gpt-5.4-xhigh) exhausted 5 transient retries: stream disconnected before completion".to_owned(),
+            details: "reviewer-1 (codex/gpt-5.5-xhigh) exhausted 5 transient retries: stream disconnected before completion".to_owned(),
             failure_class: Some(FailureClass::TransportFailure),
         };
 
@@ -4633,7 +4633,7 @@ mod tests {
             .len() as u64;
         let panel = FinalReviewPanelResolution {
             reviewers: vec![ResolvedPanelMember {
-                target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4-xhigh"),
+                target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5-xhigh"),
                 required: true,
                 configured_index: 0,
             }],
@@ -4735,7 +4735,7 @@ mod tests {
             .len() as u64;
         let panel = FinalReviewPanelResolution {
             reviewers: vec![ResolvedPanelMember {
-                target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4-xhigh"),
+                target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5-xhigh"),
                 required: true,
                 configured_index: 0,
             }],
@@ -4829,7 +4829,7 @@ mod tests {
             .len() as u64;
         let panel = FinalReviewPanelResolution {
             reviewers: vec![ResolvedPanelMember {
-                target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4-xhigh"),
+                target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5-xhigh"),
                 required: true,
                 configured_index: 0,
             }],
@@ -4902,7 +4902,7 @@ mod tests {
         let panel = FinalReviewPanelResolution {
             reviewers: vec![
                 ResolvedPanelMember {
-                    target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4-xhigh"),
+                    target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5-xhigh"),
                     required: false,
                     configured_index: 0,
                 },
@@ -4982,7 +4982,7 @@ mod tests {
         let base_dir = tmp.path();
         let project_id = setup_project(base_dir, "fr-reviewer-availability-retry");
         let adapter = RecordingFinalReviewAdapter::with_scripted_availability_failures(
-            "gpt-5.4-xhigh",
+            "gpt-5.5-xhigh",
             vec!["availability probe failed: connection reset by peer"],
         );
         let agent_service =
@@ -4995,7 +4995,7 @@ mod tests {
             .len() as u64;
         let panel = FinalReviewPanelResolution {
             reviewers: vec![ResolvedPanelMember {
-                target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4-xhigh"),
+                target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5-xhigh"),
                 required: true,
                 configured_index: 0,
             }],
@@ -5034,7 +5034,7 @@ mod tests {
             "stage should complete after the availability retry"
         );
         assert!(
-            adapter.availability_checks_for("gpt-5.4-xhigh") >= 2,
+            adapter.availability_checks_for("gpt-5.5-xhigh") >= 2,
             "proposal availability should be rechecked after the transient failure"
         );
         assert_eq!(adapter.invocation_ids_for("final_review:reviewer").len(), 1);
@@ -5056,7 +5056,7 @@ mod tests {
         let base_dir = tmp.path();
         let project_id = setup_project(base_dir, "fr-reviewer-availability-rate-limit-retry");
         let adapter = RecordingFinalReviewAdapter::with_scripted_availability_failures(
-            "gpt-5.4-xhigh",
+            "gpt-5.5-xhigh",
             vec!["HTTP 429: Too Many Requests"],
         );
         let agent_service =
@@ -5070,7 +5070,7 @@ mod tests {
             .len() as u64;
         let panel = FinalReviewPanelResolution {
             reviewers: vec![ResolvedPanelMember {
-                target: ResolvedBackendTarget::new(BackendFamily::OpenRouter, "gpt-5.4-xhigh"),
+                target: ResolvedBackendTarget::new(BackendFamily::OpenRouter, "gpt-5.5-xhigh"),
                 required: true,
                 configured_index: 0,
             }],
@@ -5109,7 +5109,7 @@ mod tests {
             "stage should complete after the transient 429 availability retry"
         );
         assert!(
-            adapter.availability_checks_for("gpt-5.4-xhigh") >= 2,
+            adapter.availability_checks_for("gpt-5.5-xhigh") >= 2,
             "proposal availability should be rechecked after the transient 429 failure"
         );
         assert_eq!(adapter.invocation_ids_for("final_review:reviewer").len(), 1);
@@ -5146,7 +5146,7 @@ mod tests {
             .len() as u64;
         let panel = FinalReviewPanelResolution {
             reviewers: vec![ResolvedPanelMember {
-                target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4-xhigh"),
+                target: ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5-xhigh"),
                 required: true,
                 configured_index: 0,
             }],

--- a/src/contexts/workspace_governance/config.rs
+++ b/src/contexts/workspace_governance/config.rs
@@ -1554,7 +1554,7 @@ fn default_final_review_backends() -> Vec<PanelBackendSpec> {
     vec![
         PanelBackendSpec::required_selection(BackendSelection::new(
             BackendFamily::Codex,
-            Some("gpt-5.4-xhigh".to_owned()),
+            Some("gpt-5.5-xhigh".to_owned()),
         )),
         PanelBackendSpec::optional_selection(BackendSelection::new(
             BackendFamily::Claude,
@@ -1604,9 +1604,9 @@ fn default_backend_runtime_settings(backend_name: &str) -> AppResult<BackendRunt
         timeout_seconds: None,
         role_models: match backend_name {
             "codex" => BackendRoleModels {
-                implementer: Some("gpt-5.4-high".to_owned()),
-                final_reviewer: Some("gpt-5.4-xhigh".to_owned()),
-                arbiter: Some("gpt-5.4-xhigh".to_owned()),
+                implementer: Some("gpt-5.5-high".to_owned()),
+                final_reviewer: Some("gpt-5.5-xhigh".to_owned()),
+                arbiter: Some("gpt-5.5-xhigh".to_owned()),
                 ..Default::default()
             },
             "claude" => BackendRoleModels {

--- a/src/shared/domain.rs
+++ b/src/shared/domain.rs
@@ -83,8 +83,8 @@ impl BackendFamily {
     pub fn default_model_id(self) -> &'static str {
         match self {
             Self::Claude => "claude-opus-4-7",
-            Self::Codex => "gpt-5.4",
-            Self::OpenRouter => "openai/gpt-5.4",
+            Self::Codex => "gpt-5.5",
+            Self::OpenRouter => "openai/gpt-5.5",
             Self::Stub => "stub-default",
         }
     }
@@ -252,10 +252,10 @@ impl BackendRole {
     pub fn default_target(self) -> ResolvedBackendTarget {
         match self {
             Self::Planner => ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-7"),
-            Self::Implementer => ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4-high"),
-            Self::Reviewer => ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4"),
+            Self::Implementer => ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5-high"),
+            Self::Reviewer => ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5"),
             Self::QaValidator => {
-                ResolvedBackendTarget::new(BackendFamily::OpenRouter, "openai/gpt-5.4")
+                ResolvedBackendTarget::new(BackendFamily::OpenRouter, "openai/gpt-5.5")
             }
             Self::CompletionJudge => {
                 ResolvedBackendTarget::new(BackendFamily::Claude, "claude-opus-4-7")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12120,8 +12120,8 @@ fn run_tail_with_logs_renders_final_review_member_timing_summary() {
 
     let journal_path = project_root(temp_dir.path(), "tail-reviewers").join("journal.ndjson");
     let reviewer_events = [
-        r#"{"sequence":2,"timestamp":"2026-04-02T10:00:00Z","event_type":"reviewer_started","details":{"run_id":"run-1","stage_id":"final_review","cycle":1,"attempt":1,"completion_round":1,"panel":"final_review","phase":"proposal","reviewer_id":"reviewer-2","role":"reviewer","backend_family":"codex","model_id":"gpt-5.4"}}"#,
-        r#"{"sequence":3,"timestamp":"2026-04-02T10:00:05Z","event_type":"reviewer_completed","details":{"run_id":"run-1","stage_id":"final_review","cycle":1,"attempt":1,"completion_round":1,"panel":"final_review","phase":"proposal","reviewer_id":"reviewer-2","role":"reviewer","backend_family":"codex","model_id":"gpt-5.4","duration_ms":37,"outcome":"proposed_amendments","amendment_count":2}}"#,
+        r#"{"sequence":2,"timestamp":"2026-04-02T10:00:00Z","event_type":"reviewer_started","details":{"run_id":"run-1","stage_id":"final_review","cycle":1,"attempt":1,"completion_round":1,"panel":"final_review","phase":"proposal","reviewer_id":"reviewer-2","role":"reviewer","backend_family":"codex","model_id":"gpt-5.5"}}"#,
+        r#"{"sequence":3,"timestamp":"2026-04-02T10:00:05Z","event_type":"reviewer_completed","details":{"run_id":"run-1","stage_id":"final_review","cycle":1,"attempt":1,"completion_round":1,"panel":"final_review","phase":"proposal","reviewer_id":"reviewer-2","role":"reviewer","backend_family":"codex","model_id":"gpt-5.5","duration_ms":37,"outcome":"proposed_amendments","amendment_count":2}}"#,
     ]
     .join("\n")
         + "\n";
@@ -12140,7 +12140,7 @@ fn run_tail_with_logs_renders_final_review_member_timing_summary() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("final_review reviewer reviewer-2 proposal [codex / gpt-5.4]"));
+    assert!(stdout.contains("final_review reviewer reviewer-2 proposal [codex / gpt-5.5]"));
     assert!(
         stdout.contains(
             "final_review reviewer reviewer-2 proposal completed in 37ms outcome=proposed_amendments amendments=2"
@@ -19500,7 +19500,7 @@ fn backend_probe_final_reviewer() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("gpt-5.4-xhigh"),
+        stdout.contains("gpt-5.5-xhigh"),
         "should show the default first final reviewer target: {}",
         stdout
     );

--- a/tests/unit/agent_execution_test.rs
+++ b/tests/unit/agent_execution_test.rs
@@ -442,7 +442,7 @@ async fn service_reuses_supported_sessions_and_persists_updated_metadata() {
         sessions: vec![SessionMetadata {
             role: BackendRole::Implementer,
             backend_family: BackendFamily::Codex,
-            model_id: "gpt-5.4-high".to_owned(),
+            model_id: "gpt-5.5-high".to_owned(),
             session_id: "existing-session".to_owned(),
             created_at: timestamp,
             last_used_at: timestamp,

--- a/tests/unit/automation_runtime_test.rs
+++ b/tests/unit/automation_runtime_test.rs
@@ -3537,8 +3537,8 @@ async fn daemon_requirements_quick_honors_workspace_backend_model_defaults() {
     let temp = tempdir().expect("tempdir");
     let base_dir = temp.path();
 
-    // Set up workspace with explicit defaults (codex / gpt-5.4)
-    let effective_config = setup_workspace_with_defaults(base_dir, "codex", "gpt-5.4");
+    // Set up workspace with explicit defaults (codex / gpt-5.5)
+    let effective_config = setup_workspace_with_defaults(base_dir, "codex", "gpt-5.5");
 
     // Build the service the same way the daemon does after the fix
     let adapter = ralph_burning::adapters::stub_backend::StubBackendAdapter::default();
@@ -3565,8 +3565,8 @@ async fn daemon_requirements_quick_honors_workspace_backend_model_defaults() {
             inv.resolved_target.backend.family
         );
         assert_eq!(
-            "gpt-5.4", inv.resolved_target.model.model_id,
-            "invocation '{}' should use workspace default model (gpt-5.4), got {}",
+            "gpt-5.5", inv.resolved_target.model.model_id,
+            "invocation '{}' should use workspace default model (gpt-5.5), got {}",
             inv.contract_label, inv.resolved_target.model.model_id
         );
     }
@@ -3581,8 +3581,8 @@ async fn daemon_requirements_draft_honors_workspace_backend_model_defaults() {
     let temp = tempdir().expect("tempdir");
     let base_dir = temp.path();
 
-    // Set up workspace with explicit defaults (codex / gpt-5.4)
-    let effective_config = setup_workspace_with_defaults(base_dir, "codex", "gpt-5.4");
+    // Set up workspace with explicit defaults (codex / gpt-5.5)
+    let effective_config = setup_workspace_with_defaults(base_dir, "codex", "gpt-5.5");
 
     // Build the service the same way the daemon does after the fix
     let adapter = ralph_burning::adapters::stub_backend::StubBackendAdapter::default();
@@ -3609,8 +3609,8 @@ async fn daemon_requirements_draft_honors_workspace_backend_model_defaults() {
             inv.resolved_target.backend.family
         );
         assert_eq!(
-            "gpt-5.4", inv.resolved_target.model.model_id,
-            "invocation '{}' should use workspace default model (gpt-5.4), got {}",
+            "gpt-5.5", inv.resolved_target.model.model_id,
+            "invocation '{}' should use workspace default model (gpt-5.5), got {}",
             inv.contract_label, inv.resolved_target.model.model_id
         );
     }

--- a/tests/unit/backend_diagnostics_test.rs
+++ b/tests/unit/backend_diagnostics_test.rs
@@ -276,7 +276,7 @@ fn show_effective_reports_compiled_implementer_default_source() {
         .find(|r| r.role == "implementer")
         .expect("implementer row should exist");
     assert_eq!("codex", implementer.backend_family);
-    assert_eq!("gpt-5.4-high", implementer.model_id);
+    assert_eq!("gpt-5.5-high", implementer.model_id);
     assert_eq!(
         "workflow.implementer_backend (default)", implementer.override_source,
         "compiled implementer default should be attributed to workflow.implementer_backend"
@@ -654,7 +654,7 @@ fn show_effective_reports_final_review_panel_members() {
         .find(|r| r.role == "final_reviewer")
         .expect("compatibility final_reviewer row should exist");
     assert_eq!("codex", final_reviewer.backend_family);
-    assert_eq!("gpt-5.4-xhigh", final_reviewer.model_id);
+    assert_eq!("gpt-5.5-xhigh", final_reviewer.model_id);
     assert_eq!(
         "final_review.backends (default)",
         final_reviewer.model_source
@@ -666,7 +666,7 @@ fn show_effective_reports_final_review_panel_members() {
         .find(|r| r.role == "final_review_panel.reviewer[0]")
         .expect("first final-review reviewer row should exist");
     assert_eq!("codex", reviewer0.backend_family);
-    assert_eq!("gpt-5.4-xhigh", reviewer0.model_id);
+    assert_eq!("gpt-5.5-xhigh", reviewer0.model_id);
     assert_eq!("final_review.backends (default)", reviewer0.override_source);
     assert_eq!("final_review.backends (default)", reviewer0.model_source);
 
@@ -686,7 +686,7 @@ fn show_effective_reports_final_review_panel_members() {
         .find(|r| r.role == "arbiter")
         .expect("arbiter row should exist");
     assert_eq!("codex", arbiter.backend_family);
-    assert_eq!("gpt-5.4-xhigh", arbiter.model_id);
+    assert_eq!("gpt-5.5-xhigh", arbiter.model_id);
     assert_eq!(
         "final_review.arbiter_backend (default)",
         arbiter.override_source
@@ -716,9 +716,9 @@ fn show_effective_final_reviewer_uses_explicit_default_model_before_compiled_cod
         .iter()
         .find(|r| r.role == "final_reviewer")
         .expect("compatibility final_reviewer row should exist");
-    // First reviewer has an inline model override (gpt-5.4-xhigh), unaffected
+    // First reviewer has an inline model override (gpt-5.5-xhigh), unaffected
     // by default_model.
-    assert_eq!("gpt-5.4-xhigh", final_reviewer.model_id);
+    assert_eq!("gpt-5.5-xhigh", final_reviewer.model_id);
     assert_eq!(
         "final_review.backends (default)",
         final_reviewer.model_source
@@ -729,7 +729,7 @@ fn show_effective_final_reviewer_uses_explicit_default_model_before_compiled_cod
         .iter()
         .find(|r| r.role == "final_review_panel.reviewer[0]")
         .expect("first final-review reviewer row should exist");
-    assert_eq!("gpt-5.4-xhigh", reviewer0.model_id);
+    assert_eq!("gpt-5.5-xhigh", reviewer0.model_id);
     assert_eq!("final_review.backends (default)", reviewer0.model_source);
 }
 
@@ -752,7 +752,7 @@ fn probe_singular_final_reviewer_returns_first_panel_member() {
         .target
         .expect("singular role probe should return a target");
     assert_eq!("codex", target.backend_family);
-    assert_eq!("gpt-5.4-xhigh", target.model_id);
+    assert_eq!("gpt-5.5-xhigh", target.model_id);
 }
 
 #[test]
@@ -781,9 +781,9 @@ fn probe_implementer_and_final_reviewer_use_explicit_default_model_before_compil
         .expect("final reviewer probe should resolve");
     let final_reviewer_target = final_reviewer.target.expect("final reviewer target");
     assert_eq!("codex", final_reviewer_target.backend_family);
-    // First reviewer has an inline model override (gpt-5.4-xhigh), unaffected
+    // First reviewer has an inline model override (gpt-5.5-xhigh), unaffected
     // by default_model.
-    assert_eq!("gpt-5.4-xhigh", final_reviewer_target.model_id);
+    assert_eq!("gpt-5.5-xhigh", final_reviewer_target.model_id);
 }
 
 #[test]

--- a/tests/unit/backend_policy_test.rs
+++ b/tests/unit/backend_policy_test.rs
@@ -63,7 +63,7 @@ fn compiled_defaults_use_codex_high_implementer_and_cross_model_final_review_pan
         .resolve_role_target(BackendPolicyRole::Implementer, 1)
         .expect("resolve implementer");
     assert_eq!(BackendFamily::Codex, implementer.backend.family);
-    assert_eq!("gpt-5.4-high", implementer.model.model_id);
+    assert_eq!("gpt-5.5-high", implementer.model.model_id);
 
     let panel = policy
         .resolve_final_review_panel(1)
@@ -73,7 +73,7 @@ fn compiled_defaults_use_codex_high_implementer_and_cross_model_final_review_pan
         BackendFamily::Codex,
         panel.reviewers[0].target.backend.family
     );
-    assert_eq!("gpt-5.4-xhigh", panel.reviewers[0].target.model.model_id);
+    assert_eq!("gpt-5.5-xhigh", panel.reviewers[0].target.model.model_id);
     assert_eq!(
         BackendFamily::Claude,
         panel.reviewers[1].target.backend.family
@@ -93,7 +93,7 @@ fn compiled_defaults_use_codex_high_implementer_and_cross_model_final_review_pan
     );
     assert!(!panel.reviewers[2].required);
     assert_eq!(BackendFamily::Codex, panel.arbiter.backend.family);
-    assert_eq!("gpt-5.4-xhigh", panel.arbiter.model.model_id);
+    assert_eq!("gpt-5.5-xhigh", panel.arbiter.model.model_id);
 }
 
 #[test]
@@ -199,9 +199,9 @@ fn compiled_default_final_review_panel_honors_role_model_overrides() {
         BackendFamily::Codex,
         panel.reviewers[0].target.backend.family
     );
-    // First reviewer has an inline model override (gpt-5.4-xhigh) that is not
+    // First reviewer has an inline model override (gpt-5.5-xhigh) that is not
     // affected by role_models overrides.
-    assert_eq!("gpt-5.4-xhigh", panel.reviewers[0].target.model.model_id);
+    assert_eq!("gpt-5.5-xhigh", panel.reviewers[0].target.model.model_id);
     assert_eq!(
         BackendFamily::Claude,
         panel.reviewers[1].target.backend.family
@@ -247,9 +247,9 @@ fn explicit_default_model_overrides_compiled_codex_role_defaults() {
         .resolve_final_review_panel(1)
         .expect("resolve final review panel");
     assert_eq!(3, panel.reviewers.len());
-    // First reviewer has an inline model override (gpt-5.4-xhigh), unaffected
+    // First reviewer has an inline model override (gpt-5.5-xhigh), unaffected
     // by default_model.
-    assert_eq!("gpt-5.4-xhigh", panel.reviewers[0].target.model.model_id);
+    assert_eq!("gpt-5.5-xhigh", panel.reviewers[0].target.model.model_id);
     // Second reviewer has an inline model override (claude-opus-4-7-max),
     // unaffected by default_model.
     assert_eq!(
@@ -511,7 +511,7 @@ fn final_review_panel_resolution_includes_reviewers_and_arbiter() {
         "final-review reviewers should resolve"
     );
     assert_eq!(BackendFamily::Codex, panel.arbiter.backend.family);
-    assert_eq!("gpt-5.4-xhigh", panel.arbiter.model.model_id);
+    assert_eq!("gpt-5.5-xhigh", panel.arbiter.model.model_id);
 }
 
 #[test]
@@ -538,7 +538,7 @@ fn final_review_panel_supports_same_family_with_distinct_models() {
         )),
         PanelBackendSpec::required_selection(BackendSelection::new(
             BackendFamily::Codex,
-            Some("gpt-5.4-xhigh".to_owned()),
+            Some("gpt-5.5-xhigh".to_owned()),
         )),
     ]);
     workspace.final_review.min_reviewers = Some(2);
@@ -562,7 +562,7 @@ fn final_review_panel_supports_same_family_with_distinct_models() {
         BackendFamily::Codex,
         panel.reviewers[1].target.backend.family
     );
-    assert_eq!("gpt-5.4-xhigh", panel.reviewers[1].target.model.model_id);
+    assert_eq!("gpt-5.5-xhigh", panel.reviewers[1].target.model.model_id);
 }
 
 #[test]

--- a/tests/unit/backend_resolver_test.rs
+++ b/tests/unit/backend_resolver_test.rs
@@ -24,5 +24,5 @@ fn backend_resolver_preserves_role_specific_default_model_when_backend_family_ch
 
     assert_eq!(resolved.backend.family, BackendFamily::Codex);
     assert_eq!(resolved.model.backend_family, BackendFamily::Codex);
-    assert_eq!(resolved.model.model_id, "gpt-5.4-high");
+    assert_eq!(resolved.model.model_id, "gpt-5.5-high");
 }

--- a/tests/unit/config_test.rs
+++ b/tests/unit/config_test.rs
@@ -55,7 +55,7 @@ fn effective_config_loads_compiled_defaults() {
     );
     assert_eq!(
         vec![
-            "codex/gpt-5.4-xhigh".to_owned(),
+            "codex/gpt-5.5-xhigh".to_owned(),
             "?claude/claude-opus-4-7-max".to_owned(),
             "?codex/gpt-5.3-codex-spark-xhigh".to_owned(),
         ],
@@ -69,7 +69,7 @@ fn effective_config_loads_compiled_defaults() {
         }
     );
     assert_eq!(
-        Some("gpt-5.4-high".to_owned()),
+        Some("gpt-5.5-high".to_owned()),
         match config
             .get("backends.codex.role_models.implementer")
             .expect("codex implementer role model")
@@ -91,7 +91,7 @@ fn effective_config_loads_compiled_defaults() {
         }
     );
     assert_eq!(
-        Some("gpt-5.4-xhigh".to_owned()),
+        Some("gpt-5.5-xhigh".to_owned()),
         match config
             .get("backends.codex.role_models.arbiter")
             .expect("codex arbiter role model")
@@ -113,7 +113,7 @@ fn effective_config_loads_compiled_defaults() {
         }
     );
     assert_eq!(
-        Some("gpt-5.4-xhigh".to_owned()),
+        Some("gpt-5.5-xhigh".to_owned()),
         match config
             .get("backends.codex.role_models.final_reviewer")
             .expect("codex final reviewer role model")
@@ -582,12 +582,12 @@ fn config_set_accepts_panel_backend_model_overrides_and_displays_them() {
     let entry = EffectiveConfig::set(
         temp_dir.path(),
         "final_review.backends",
-        r#"["codex/gpt-5.4-xhigh", "?codex/gpt-5.3-codex-spark-xhigh"]"#,
+        r#"["codex/gpt-5.5-xhigh", "?codex/gpt-5.3-codex-spark-xhigh"]"#,
     )
     .expect("set final review backends");
 
     assert_eq!(
-        r#"["codex/gpt-5.4-xhigh", "?codex/gpt-5.3-codex-spark-xhigh"]"#,
+        r#"["codex/gpt-5.5-xhigh", "?codex/gpt-5.3-codex-spark-xhigh"]"#,
         entry.value.toml_like_value()
     );
 
@@ -596,7 +596,7 @@ fn config_set_accepts_panel_backend_model_overrides_and_displays_them() {
         .get("final_review.backends")
         .expect("get final review backends");
     assert_eq!(
-        r#"["codex/gpt-5.4-xhigh", "?codex/gpt-5.3-codex-spark-xhigh"]"#,
+        r#"["codex/gpt-5.5-xhigh", "?codex/gpt-5.3-codex-spark-xhigh"]"#,
         fetched.value.toml_like_value()
     );
 }
@@ -609,12 +609,12 @@ fn config_set_accepts_legacy_parenthesized_panel_backend_model_overrides() {
     let entry = EffectiveConfig::set(
         temp_dir.path(),
         "final_review.backends",
-        r#"["openrouter(openai/gpt-5.4)", "?openrouter(openai/gpt-5.4-mini)"]"#,
+        r#"["openrouter(openai/gpt-5.5)", "?openrouter(openai/gpt-5.5-mini)"]"#,
     )
     .expect("set final review backends");
 
     assert_eq!(
-        r#"["openrouter/openai/gpt-5.4", "?openrouter/openai/gpt-5.4-mini"]"#,
+        r#"["openrouter/openai/gpt-5.5", "?openrouter/openai/gpt-5.5-mini"]"#,
         entry.value.toml_like_value()
     );
 
@@ -623,7 +623,7 @@ fn config_set_accepts_legacy_parenthesized_panel_backend_model_overrides() {
         .get("final_review.backends")
         .expect("get final review backends");
     assert_eq!(
-        r#"["openrouter/openai/gpt-5.4", "?openrouter/openai/gpt-5.4-mini"]"#,
+        r#"["openrouter/openai/gpt-5.5", "?openrouter/openai/gpt-5.5-mini"]"#,
         fetched.value.toml_like_value()
     );
 }

--- a/tests/unit/domain_test.rs
+++ b/tests/unit/domain_test.rs
@@ -96,25 +96,25 @@ fn project_id_rejects_path_like_values() {
 
 #[test]
 fn panel_backend_spec_parses_inline_model_overrides_and_optional_marker() {
-    let required = "codex/gpt-5.4-xhigh"
+    let required = "codex/gpt-5.5-xhigh"
         .parse::<PanelBackendSpec>()
         .expect("parse required panel backend");
-    let optional = "?openrouter/openai/gpt-5.4"
+    let optional = "?openrouter/openai/gpt-5.5"
         .parse::<PanelBackendSpec>()
         .expect("parse optional panel backend");
 
     assert_eq!(BackendFamily::Codex, required.selection().family);
-    assert_eq!(Some("gpt-5.4-xhigh"), required.selection().model.as_deref());
+    assert_eq!(Some("gpt-5.5-xhigh"), required.selection().model.as_deref());
     assert!(!required.is_optional());
-    assert_eq!("codex/gpt-5.4-xhigh", required.to_string());
+    assert_eq!("codex/gpt-5.5-xhigh", required.to_string());
 
     assert_eq!(BackendFamily::OpenRouter, optional.selection().family);
     assert_eq!(
-        Some("openai/gpt-5.4"),
+        Some("openai/gpt-5.5"),
         optional.selection().model.as_deref()
     );
     assert!(optional.is_optional());
-    assert_eq!("?openrouter/openai/gpt-5.4", optional.to_string());
+    assert_eq!("?openrouter/openai/gpt-5.5", optional.to_string());
 }
 
 #[test]
@@ -141,23 +141,23 @@ fn panel_backend_spec_serde_round_trips_inline_model_overrides() {
 
 #[test]
 fn panel_backend_spec_parses_legacy_parenthesized_model_overrides_with_slashes() {
-    let required = "openrouter(openai/gpt-5.4)"
+    let required = "openrouter(openai/gpt-5.5)"
         .parse::<PanelBackendSpec>()
         .expect("parse required legacy panel backend");
-    let optional = "?openrouter(openai/gpt-5.4)"
+    let optional = "?openrouter(openai/gpt-5.5)"
         .parse::<PanelBackendSpec>()
         .expect("parse optional legacy panel backend");
 
     assert_eq!(BackendFamily::OpenRouter, required.selection().family);
     assert_eq!(
-        Some("openai/gpt-5.4"),
+        Some("openai/gpt-5.5"),
         required.selection().model.as_deref()
     );
     assert!(!required.is_optional());
 
     assert_eq!(BackendFamily::OpenRouter, optional.selection().family);
     assert_eq!(
-        Some("openai/gpt-5.4"),
+        Some("openai/gpt-5.5"),
         optional.selection().model.as_deref()
     );
     assert!(optional.is_optional());
@@ -170,22 +170,22 @@ fn panel_backend_spec_serde_accepts_legacy_parenthesized_model_overrides() {
         spec: PanelBackendSpec,
     }
 
-    let from_json: Wrapper = serde_json::from_str(r#"{"spec":"?openrouter(openai/gpt-5.4)"}"#)
+    let from_json: Wrapper = serde_json::from_str(r#"{"spec":"?openrouter(openai/gpt-5.5)"}"#)
         .expect("deserialize legacy panel backend from json");
     assert_eq!(BackendFamily::OpenRouter, from_json.spec.selection().family);
     assert_eq!(
-        Some("openai/gpt-5.4"),
+        Some("openai/gpt-5.5"),
         from_json.spec.selection().model.as_deref()
     );
     assert_eq!(
-        r#"{"spec":"?openrouter/openai/gpt-5.4"}"#,
+        r#"{"spec":"?openrouter/openai/gpt-5.5"}"#,
         serde_json::to_string(&from_json).expect("serialize normalized panel backend to json")
     );
 
-    let from_toml: Wrapper = toml::from_str("spec = \"?openrouter(openai/gpt-5.4)\"")
+    let from_toml: Wrapper = toml::from_str("spec = \"?openrouter(openai/gpt-5.5)\"")
         .expect("deserialize legacy panel backend from toml");
     assert_eq!(from_json, from_toml);
     assert!(toml::to_string(&from_toml)
         .expect("serialize normalized panel backend to toml")
-        .contains("?openrouter/openai/gpt-5.4"));
+        .contains("?openrouter/openai/gpt-5.5"));
 }

--- a/tests/unit/journal_test.rs
+++ b/tests/unit/journal_test.rs
@@ -321,7 +321,7 @@ fn reviewer_completed_event_builder_serializes_timing_metadata() {
         "reviewer-2",
         "reviewer",
         "codex",
-        "gpt-5.4",
+        "gpt-5.5",
         37,
         "proposed_amendments",
         2,

--- a/tests/unit/process_backend_test.rs
+++ b/tests/unit/process_backend_test.rs
@@ -1097,12 +1097,12 @@ async fn codex_resume_suffix_model_adds_reasoning_effort_override() {
     let _path_guard = PathGuard::prepend(bin_dir.path());
 
     let (_dir, mut request) = request_fixture(BackendFamily::Codex);
-    request.resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4-xhigh");
+    request.resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5-xhigh");
     request.session_policy = SessionPolicy::ReuseIfAllowed;
     request.prior_session = Some(SessionMetadata {
         role: BackendRole::Implementer,
         backend_family: BackendFamily::Codex,
-        model_id: "gpt-5.4-xhigh".to_owned(),
+        model_id: "gpt-5.5-xhigh".to_owned(),
         session_id: "codex-ses-456".to_owned(),
         created_at: Utc::now(),
         last_used_at: Utc::now(),
@@ -1142,7 +1142,7 @@ async fn codex_resume_suffix_model_adds_reasoning_effort_override() {
             "--dangerously-bypass-approvals-and-sandbox".to_owned(),
             "--skip-git-repo-check".to_owned(),
             "--model".to_owned(),
-            "gpt-5.4".to_owned(),
+            "gpt-5.5".to_owned(),
             "-c".to_owned(),
             "model_reasoning_effort=\"xhigh\"".to_owned(),
             "--output-schema".to_owned(),
@@ -1162,12 +1162,12 @@ async fn codex_resume_fast_suffix_adds_service_tier_override() {
     let _path_guard = PathGuard::prepend(bin_dir.path());
 
     let (_dir, mut request) = request_fixture(BackendFamily::Codex);
-    request.resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.4-fast");
+    request.resolved_target = ResolvedBackendTarget::new(BackendFamily::Codex, "gpt-5.5-fast");
     request.session_policy = SessionPolicy::ReuseIfAllowed;
     request.prior_session = Some(SessionMetadata {
         role: BackendRole::Implementer,
         backend_family: BackendFamily::Codex,
-        model_id: "gpt-5.4-fast".to_owned(),
+        model_id: "gpt-5.5-fast".to_owned(),
         session_id: "codex-ses-456".to_owned(),
         created_at: Utc::now(),
         last_used_at: Utc::now(),
@@ -1207,7 +1207,7 @@ async fn codex_resume_fast_suffix_adds_service_tier_override() {
             "--dangerously-bypass-approvals-and-sandbox".to_owned(),
             "--skip-git-repo-check".to_owned(),
             "--model".to_owned(),
-            "gpt-5.4".to_owned(),
+            "gpt-5.5".to_owned(),
             "-c".to_owned(),
             "service_tier=\"fast\"".to_owned(),
             "--output-schema".to_owned(),

--- a/tests/unit/project_run_record_test.rs
+++ b/tests/unit/project_run_record_test.rs
@@ -2913,7 +2913,7 @@ fn active_run_with_snapshot_round_trip() {
             }),
             stage_target: Some(ResolvedTargetRecord {
                 backend_family: "codex".to_owned(),
-                model_id: "gpt-5.4".to_owned(),
+                model_id: "gpt-5.5".to_owned(),
             }),
         }),
         stage_resolution_snapshot: Some(StageResolutionSnapshot {

--- a/tests/unit/stub_backend_test.rs
+++ b/tests/unit/stub_backend_test.rs
@@ -91,7 +91,7 @@ async fn stub_backend_reuses_prior_session_when_role_and_backend_allow_it() {
     request.prior_session = Some(SessionMetadata {
         role: BackendRole::Implementer,
         backend_family: BackendFamily::Codex,
-        model_id: "gpt-5.4-high".to_owned(),
+        model_id: "gpt-5.5-high".to_owned(),
         session_id: "existing-session".to_owned(),
         created_at: timestamp,
         last_used_at: timestamp,


### PR DESCRIPTION
## Summary
- Bump default codex model identifiers from \`gpt-5.4\` to \`gpt-5.5\` everywhere in production code and tests.

### Production defaults updated
- \`src/contexts/workspace_governance/config.rs\` — \`default_final_review_backends\` required entry, and \`default_backend_runtime_settings(\"codex\")\` role models for implementer / final_reviewer / arbiter.
- \`src/adapters/process_backend.rs\` — \`codex_model_reasoning_effort_and_fast\` parser examples and unit tests bumped.

### Test fixtures updated
- All \`tests/unit/*.rs\` and \`src/contexts/{workflow_composition,conformance_spec}/*.rs\` test cases that hardcoded \`gpt-5.4\` model names. \`tests/cli.rs\` snapshot strings also bumped.

### Not changed
- \`gpt-5.3-codex-spark-xhigh\` (the optional spark variant) remains as-is — different model line.
- claude defaults are untouched.
- Historical artifacts under \`.ralph/\`, \`.beads/issues.jsonl\`, \`docs/loops/\`, \`docs/signoff/\`, \`prompt-*.md\` are untouched (history, not active config).
- Backend role-string identifiers, suffix-parsing rules, and panel composition logic are unchanged — only the model identifier moves 5.4 → 5.5.

## Test plan
- [x] \`nix develop -c cargo fmt --check\`
- [x] \`nix develop -c cargo clippy --locked -- -D warnings\`
- [x] \`nix develop -c cargo test --locked --features test-stub\` (1220 + 373 + 1079 pass; 0 failures)
- [x] \`nix build\`

## Diff scope
18 files changed, 112 insertions, 112 deletions — pure model-string substitution, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)