### PR TITLE
fix(schema): drop schemars(default) on classification fields, breaks gpt-5.5 strict mode (ralph-burning-c2e)

### DIFF
--- a/src/contexts/workflow_composition/panel_contracts.rs
+++ b/src/contexts/workflow_composition/panel_contracts.rs
@@ -178,9 +178,12 @@ pub struct FinalReviewProposal {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub covered_by_bead_id: Option<String>,
     /// Classification for this amendment. Missing classifications default to
-    /// `fix_current_bead` for backward compatibility.
+    /// `fix_current_bead` for backward compatibility. The `#[schemars(default
+    /// = ...)]` attribute is intentionally omitted — gpt-5.5 strict-mode
+    /// structured outputs reject the `allOf` schemars emits when an enum is
+    /// paired with a `default` function. Serde still applies the default at
+    /// deserialize time.
     #[serde(default = "default_review_finding_class")]
-    #[schemars(default = "default_review_finding_class")]
     pub classification: AmendmentClassification,
     /// Title to use when an accepted `propose-new-bead` amendment creates
     /// follow-up work.
@@ -313,9 +316,9 @@ pub struct FinalReviewCanonicalAmendment {
     /// Bead ID when `classification` is `covered_by_existing_bead`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub covered_by_bead_id: Option<String>,
-    /// Classification for routing and inspectability.
+    /// Classification for routing and inspectability. `#[schemars(default =
+    /// ...)]` intentionally omitted — see field above for context.
     #[serde(default = "default_review_finding_class")]
-    #[schemars(default = "default_review_finding_class")]
     pub classification: AmendmentClassification,
     /// Reviewer-provided rationale preserved for downstream routing.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/contexts/workflow_composition/payloads.rs
+++ b/src/contexts/workflow_composition/payloads.rs
@@ -102,9 +102,11 @@ struct ClassifiedFindingWire {
 pub struct ClassifiedFinding {
     /// The finding body (equivalent to an item in `follow_up_or_amendments`).
     pub body: String,
-    /// How this finding should be routed.
+    /// How this finding should be routed. The `#[schemars(default = ...)]`
+    /// attribute is intentionally omitted — gpt-5.5 strict-mode structured
+    /// outputs reject the `allOf` schemars emits when an enum is paired with a
+    /// `default` function. Serde still applies the default at deserialize time.
     #[serde(default = "default_review_finding_class")]
-    #[schemars(default = "default_review_finding_class")]
     pub classification: ReviewFindingClass,
     /// Bead ID when classification is covered-by-existing-bead.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/unit/workflow_panels_test.rs
+++ b/tests/unit/workflow_panels_test.rs
@@ -781,3 +781,66 @@ fn prompt_review_decision_display_accepted() {
 fn prompt_review_decision_display_rejected() {
     assert_eq!(PromptReviewDecision::Rejected.to_string(), "Rejected");
 }
+
+// ── gpt-5.5 strict-mode JSON schema regression (bead c2e) ────────────────────
+
+/// Recursively verify that a generated JSON schema contains no `allOf`,
+/// `anyOf`, `not`, or other constructs that gpt-5.5 strict-mode structured
+/// outputs reject. Returns the first offending JSON path, if any.
+fn find_strict_mode_violation(
+    value: &serde_json::Value,
+    path: &str,
+) -> Option<(String, &'static str)> {
+    match value {
+        serde_json::Value::Object(map) => {
+            for forbidden in ["allOf", "anyOf", "not", "if", "then", "else"] {
+                if map.contains_key(forbidden) {
+                    return Some((path.to_owned(), forbidden));
+                }
+            }
+            for (key, child) in map {
+                let child_path = if path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{path}.{key}")
+                };
+                if let Some(found) = find_strict_mode_violation(child, &child_path) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        serde_json::Value::Array(items) => {
+            for (idx, item) in items.iter().enumerate() {
+                let child_path = format!("{path}[{idx}]");
+                if let Some(found) = find_strict_mode_violation(item, &child_path) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn final_review_proposal_payload_schema_has_no_strict_mode_violations() {
+    // Regression for bead c2e: gpt-5.5 rejects `allOf`/`anyOf` in
+    // structured-output schemas. This test snapshots the assertion that
+    // every panel_json_schema returns strict-mode-compatible JSON.
+    for stage_id in [
+        StageId::FinalReview,
+        StageId::Review,
+        StageId::PromptReview,
+        StageId::CompletionPanel,
+    ] {
+        for role in ["proposer", "voter", "arbiter", "aggregator", "primary"] {
+            let schema = panel_json_schema(stage_id, role);
+            if let Some((path, forbidden)) = find_strict_mode_violation(&schema, "") {
+                panic!(
+                    "panel_json_schema({stage_id:?}, {role:?}) contains '{forbidden}' at path '{path}' — gpt-5.5 strict-mode structured outputs will reject this schema. Schema was: {schema:#}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Solve bead ralph-burning-c2e (P0 blocker): \`gpt-5.5\` strict-mode structured outputs reject \`allOf\` in JSON schemas. After PR #182 (review classification field) merged with PR #179 (gpt-5.5 default), every final_review proposal against \`codex/gpt-5.5-xhigh\` returned a 400:
  \`\`\`
  Invalid schema for response_format 'codex_output_schema': 'allOf' is not permitted at ('properties','amendments','items','properties','classification').
  \`\`\`
- Root cause: \`schemars\` emits an outer \`allOf\` wrapper whenever an enum field is annotated with both \`#[serde(default = ...)]\` and \`#[schemars(default = ...)]\`. PR #182 set both on three classification fields.
- Fix: remove the redundant \`#[schemars(default = ...)]\` from \`FinalReviewProposal::classification\`, \`FinalReviewCanonicalAmendment::classification\`, and \`ClassifiedFinding::classification\`. Serde still applies the default at deserialize time, and the wire-format default behavior is preserved by \`FinalReviewProposalWire::classification.unwrap_or_default()\` fallback already in place.
- Add a regression test \`final_review_proposal_payload_schema_has_no_strict_mode_violations\` that scans \`panel_json_schema(stage, role)\` across all combinations and asserts no \`allOf\`, \`anyOf\`, \`not\`, \`if\`, \`then\`, or \`else\` slip back in.

## Symptom this unblocks
Discovered while running bead 9ni.8.5 on project ni85-1: every final_review proposer attempt failed → bead usw's transient-retry exhausted 5 retries → run failed at completion round 1. With this fix, future bead-backed runs against gpt-5.5 should reach the actual review phase.

## Test plan
- [x] \`nix develop -c cargo fmt --check\`
- [x] \`nix develop -c cargo clippy --locked -- -D warnings\`
- [x] \`nix develop -c cargo test --locked --features test-stub\` (1288 + 374 + 1116 pass; 0 failures, +1 regression test)
- [x] \`nix build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)