### PR TITLE
fix(schema): resolve $ref when sibling keys present (c2e follow-up #2)

### DIFF
--- a/src/adapters/process_backend.rs
+++ b/src/adapters/process_backend.rs
@@ -2565,25 +2565,47 @@ fn resolve_refs(
     expanding: &mut std::collections::HashSet<String>,
 ) {
     if let serde_json::Value::Object(map) = node {
-        // Check if this node is a `$ref` object: exactly one key `"$ref"` with a
-        // string value starting with `"#/definitions/"`.
-        if map.len() == 1 {
-            if let Some(serde_json::Value::String(ref_str)) = map.get("$ref") {
-                if let Some(name) = ref_str.strip_prefix("#/definitions/") {
-                    // Cycle guard: if this definition is already being expanded
-                    // up the call stack, leave the $ref unresolved to prevent
-                    // infinite recursion (spec: recursive refs left unresolved).
-                    if expanding.contains(name) {
-                        return;
-                    }
-                    if let Some(def) = definitions.get(name) {
-                        let mut replacement = def.clone();
-                        expanding.insert(name.to_owned());
-                        resolve_refs(&mut replacement, definitions, expanding);
-                        expanding.remove(name);
+        // Resolve `$ref` whether or not it stands alone. After
+        // `enforce_strict_mode_schema` inlines single-element `allOf`
+        // wrappers, a previously-isolated `$ref` may now have sibling
+        // metadata (description, default) hoisted up next to it. JSON
+        // Schema 2020-12 says siblings are evaluated alongside `$ref`;
+        // OpenAI's strict mode rejects unresolved `$ref` outright. Either
+        // way, the right transform is "inline the definition, keep
+        // parent-level siblings, drop the `$ref` key."
+        if let Some(serde_json::Value::String(ref_str)) = map.get("$ref").cloned() {
+            if let Some(name) = ref_str.strip_prefix("#/definitions/") {
+                // Cycle guard: if this definition is already being expanded
+                // up the call stack, leave the `$ref` unresolved to
+                // prevent infinite recursion (spec: recursive refs left
+                // unresolved).
+                if expanding.contains(name) {
+                    return;
+                }
+                if let Some(def) = definitions.get(name) {
+                    let mut replacement = def.clone();
+                    expanding.insert(name.to_owned());
+                    resolve_refs(&mut replacement, definitions, expanding);
+                    expanding.remove(name);
+
+                    if map.len() == 1 {
+                        // Pure `$ref`: replace the whole node.
                         *node = replacement;
                         return;
                     }
+
+                    // Mixed `$ref` + siblings: merge the definition's
+                    // fields into the parent. Parent fields (set on the
+                    // field site, e.g., `description`, `default`) win over
+                    // the type-level fallbacks coming from the
+                    // definition.
+                    map.remove("$ref");
+                    if let serde_json::Value::Object(replacement_map) = replacement {
+                        for (k, v) in replacement_map {
+                            map.entry(k).or_insert(v);
+                        }
+                    }
+                    // Fall through to recurse into the merged map below.
                 }
             }
         }

--- a/tests/unit/workflow_panels_test.rs
+++ b/tests/unit/workflow_panels_test.rs
@@ -786,14 +786,23 @@ fn prompt_review_decision_display_rejected() {
 
 /// Recursively verify that a generated JSON schema contains no `allOf`,
 /// `anyOf`, `not`, or other constructs that gpt-5.5 strict-mode structured
-/// outputs reject. Returns the first offending JSON path, if any.
+/// outputs reject. Also flags unresolved `$ref` keys (post-processing must
+/// inline every reference: gpt-5.5 rejects them with "reference to
+/// component … which was not found in the schema"). Returns the first
+/// offending JSON path, if any.
 fn find_strict_mode_violation(
     value: &serde_json::Value,
     path: &str,
 ) -> Option<(String, &'static str)> {
     match value {
         serde_json::Value::Object(map) => {
-            for forbidden in ["allOf", "anyOf", "not", "if", "then", "else"] {
+            // anyOf is intentionally NOT flagged here — gpt-5.5 strict
+            // mode accepts `anyOf` for the nullable-field idiom (e.g.
+            // `Option<T>` becomes `{"anyOf": [{"type": "T"}, {"type":
+            // "null"}]}`) which is the only way to express nullability
+            // in strict mode. allOf and unresolved $ref are the real
+            // blockers from the ni85 failures.
+            for forbidden in ["allOf", "not", "if", "then", "else", "$ref"] {
                 if map.contains_key(forbidden) {
                     return Some((path.to_owned(), forbidden));
                 }
@@ -837,6 +846,10 @@ fn final_review_proposal_payload_schema_has_no_strict_mode_violations() {
     use ralph_burning::contexts::agent_execution::model::InvocationContract;
     use ralph_burning::shared::domain::BackendFamily;
 
+    // Only assert on `processed_contract_schema_value` — that's the schema
+    // codex actually writes to disk and sends to OpenAI. The static
+    // `panel_json_schema` is allowed to contain `$ref`s and `definitions`;
+    // they get inlined by the strict-mode post-processor before transport.
     for stage_id in [
         StageId::FinalReview,
         StageId::Review,
@@ -844,13 +857,6 @@ fn final_review_proposal_payload_schema_has_no_strict_mode_violations() {
         StageId::CompletionPanel,
     ] {
         for role in ["proposer", "voter", "arbiter", "aggregator", "primary"] {
-            let schema = panel_json_schema(stage_id, role);
-            if let Some((path, forbidden)) = find_strict_mode_violation(&schema, "") {
-                panic!(
-                    "panel_json_schema({stage_id:?}, {role:?}) contains '{forbidden}' at path '{path}' — gpt-5.5 strict-mode structured outputs will reject this schema. Schema was: {schema:#}"
-                );
-            }
-
             let contract = InvocationContract::Panel {
                 stage_id,
                 role: role.to_owned(),
@@ -861,6 +867,27 @@ fn final_review_proposal_payload_schema_has_no_strict_mode_violations() {
                     "processed_contract_schema_value(Panel{{{stage_id:?}, {role:?}}}, Codex) contains '{forbidden}' at path '{path}' — codex sends THIS schema to OpenAI, and gpt-5.5 will reject it. Schema was: {processed:#}"
                 );
             }
+        }
+    }
+
+    // Sanity-check stage contracts too — same rules apply when the
+    // implementer / qa / completion-judge stage payload is sent.
+    for stage_id in [
+        StageId::Planning,
+        StageId::Implementation,
+        StageId::Qa,
+        StageId::Review,
+        StageId::PlanAndImplement,
+        StageId::ApplyFixes,
+    ] {
+        let contract = InvocationContract::Stage(
+            ralph_burning::contexts::workflow_composition::contracts::contract_for_stage(stage_id),
+        );
+        let processed = processed_contract_schema_value(&contract, BackendFamily::Codex);
+        if let Some((path, forbidden)) = find_strict_mode_violation(&processed, "") {
+            panic!(
+                "processed_contract_schema_value(Stage({stage_id:?}), Codex) contains '{forbidden}' at path '{path}' — gpt-5.5 will reject this schema. Schema was: {processed:#}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
PR #184 inlined single-element \`allOf\` wrappers but exposed a companion bug: \`resolve_refs\` only inlined a \`\$ref\` when it was the sole key in the object (\`map.len() == 1\`). After the allOf inliner hoisted sibling metadata (\`description\`, \`default\`) up next to the \`\$ref\`, that constraint stopped firing and the \`\$ref\` was left in the transport schema, producing a fresh 400 from gpt-5.5 on project ni85-3:

\`\`\`
reference to component '#/definitions/ReviewFindingClass' which was not found in the schema.
\`\`\`

\`inline_schema_refs\` removes \`definitions\` before transport, so any unresolved \`\$ref\` is doomed.

## Fix
Resolve \`\$ref\` regardless of sibling presence. When siblings exist, merge the definition's fields into the parent and drop the \`\$ref\` key — parent siblings (description, default set on the field site) win over inner copies. JSON Schema 2020-12 says siblings are evaluated alongside \`\$ref\`, so the merge preserves intended semantics; OpenAI strict mode rejects unresolved refs anyway.

Strengthen the regression test to:
1. Scan for unresolved \`\$ref\` in the processed schema (in addition to \`allOf\`, \`not\`, \`if/then/else\`).
2. Cover **both** Panel-contract schemas (reviewer/voter/arbiter/etc.) **and** Stage-contract schemas (planning/implementation/qa/review/plan_and_implement/apply_fixes) — both go through the same \`processed_contract_schema_value\` path and would have hit the same bug.

## Note on anyOf
gpt-5.5 accepts \`anyOf\` for the nullable-field idiom (\`Option<T>\` → \`{anyOf: [{type: T}, {type: null}]}\`) — that's the only way to express nullability in strict mode and the existing \`normalize_nullable_type_array\` helper already produces this shape. The regression test does NOT flag \`anyOf\`. Only \`allOf\`, \`not\`, \`if/then/else\`, and unresolved \`\$ref\` are blockers.

## Test plan
- [x] \`nix develop -c cargo fmt --check\`
- [x] \`nix develop -c cargo clippy --locked -- -D warnings\`
- [x] \`nix develop -c cargo test --locked --features test-stub\` (1288 + 374 + 1116 pass; 0 failures)
- [x] \`nix build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)