### PR TITLE
fix(schema): collapse oneOf-of-single-enums into unified enum

### DIFF
--- a/src/adapters/process_backend.rs
+++ b/src/adapters/process_backend.rs
@@ -2455,6 +2455,38 @@ fn normalize_nullable_type_array(map: &mut serde_json::Map<String, serde_json::V
 /// violates OpenAI's strict-mode contract. Additionally, `schemars` 0.8
 /// represents `Option<T>` as `{"type": ["T", "null"]}` which is incompatible
 /// with OpenAI strict mode's requirement for single-string `type` values.
+/// Detect schemars' "string enum" idiom: `oneOf: [{enum:[<one>], type:"string"}, ...]`.
+/// Each variant must be a single-value enum sharing the same primitive type
+/// (typically "string"). Returns `Some((values, type))` if the pattern
+/// matches, else `None`. Variant-level descriptions are intentionally
+/// dropped — they're not common and not transport-load-bearing for the
+/// string-enum case.
+fn unify_single_enum_oneof(
+    variants: &[serde_json::Value],
+) -> Option<(Vec<serde_json::Value>, String)> {
+    if variants.is_empty() {
+        return None;
+    }
+    let mut shared_type: Option<String> = None;
+    let mut values: Vec<serde_json::Value> = Vec::with_capacity(variants.len());
+    for variant in variants {
+        let map = variant.as_object()?;
+        let ty = map.get("type")?.as_str()?.to_owned();
+        let enum_arr = map.get("enum")?.as_array()?;
+        if enum_arr.len() != 1 {
+            return None;
+        }
+        let value = enum_arr.first()?.clone();
+        match &shared_type {
+            None => shared_type = Some(ty),
+            Some(existing) if *existing == ty => {}
+            Some(_) => return None,
+        }
+        values.push(value);
+    }
+    Some((values, shared_type.unwrap_or_else(|| "string".to_owned())))
+}
+
 pub(crate) fn enforce_strict_mode_schema(value: &mut serde_json::Value) {
     if let serde_json::Value::Object(map) = value {
         // Convert type arrays like ["string", "null"] to anyOf format
@@ -2474,6 +2506,24 @@ pub(crate) fn enforce_strict_mode_schema(value: &mut serde_json::Value) {
                         map.entry(k).or_insert(v);
                     }
                 }
+            }
+        }
+
+        // Collapse `oneOf: [{enum: [<single>], type: T}, ...]` into a
+        // unified `{enum: [<all>], type: T}`. schemars derives Rust enums
+        // (e.g. `enum Status { Open, Closed }`) into one-element-enum
+        // variants wrapped in oneOf — gpt-5.5 strict mode rejects that
+        // shape at field-property level even though it accepts oneOf for
+        // tagged unions at top level. The collapsed form is semantically
+        // identical for the string-enum case.
+        if let Some(serde_json::Value::Array(items)) = map.get("oneOf").cloned() {
+            if let Some(unified) = unify_single_enum_oneof(&items) {
+                map.remove("oneOf");
+                let (values, ty) = unified;
+                map.entry("enum".to_owned())
+                    .or_insert(serde_json::Value::Array(values));
+                map.entry("type".to_owned())
+                    .or_insert(serde_json::Value::String(ty));
             }
         }
 

--- a/tests/unit/workflow_panels_test.rs
+++ b/tests/unit/workflow_panels_test.rs
@@ -807,6 +807,26 @@ fn find_strict_mode_violation(
                     return Some((path.to_owned(), forbidden));
                 }
             }
+            // gpt-5.5 strict mode rejects `oneOf` at field-property
+            // level when used to represent a string enum (schemars
+            // derives `enum Foo { A, B }` into `oneOf: [{enum:[a],
+            // type:string}, {enum:[b], type:string}]`). The post-processor
+            // collapses that into `{enum:[a,b], type:string}`. Flag any
+            // `oneOf` whose variants are all single-element enum schemas
+            // — that's the schemars idiom that should have been
+            // collapsed.
+            if let Some(serde_json::Value::Array(items)) = map.get("oneOf") {
+                let all_single_enums = !items.is_empty()
+                    && items.iter().all(|item| {
+                        item.as_object()
+                            .and_then(|o| o.get("enum"))
+                            .and_then(|e| e.as_array())
+                            .is_some_and(|arr| arr.len() == 1)
+                    });
+                if all_single_enums {
+                    return Some((path.to_owned(), "oneOf-of-single-enums"));
+                }
+            }
             for (key, child) in map {
                 let child_path = if path.is_empty() {
                     key.clone()


### PR DESCRIPTION
## Summary
- Adds a post-processing collapse for the schemars idiom `oneOf: [{enum: [<value>], type: T}, ...]` → `{enum: [<all values>], type: T}` so that gpt-5.5 strict-mode schema validation accepts our derived contracts.
- Strengthens the workflow_panels regression test to flag any future `oneOf-of-single-enums` regression alongside the existing forbidden-key set.

This is the third gpt-5.5 schema regression in the same lineage (after `allOf` collapse #184 and `\$ref`-with-siblings #185). It's the blocker for bead 9ni.8.5 — the previous four runs failed because schemars emits this idiom for plain string enums (`ReviewFindingClass`, `AmendmentClassification`, `StepStatus`, etc.) and gpt-5.5 rejects schemas that contain `oneOf` at all.

## Test plan
- [x] `nix develop -c cargo test` (local) — 1288 + 374 + 1116 tests pass
- [x] `nix develop -c cargo clippy -- -D warnings` clean
- [x] `nix develop -c cargo fmt --check` clean
- [x] `nix build` passes
- [ ] CI green
- [ ] Verify det fix unblocks bead 9ni.8.5 ralph-burning run

🤖 Generated with [Claude Code](https://claude.com/claude-code)