### PR TITLE
fix(codex): reject interim ExecutionPayload before tool calls return (#188)

### DIFF
--- a/src/adapters/process_backend.rs
+++ b/src/adapters/process_backend.rs
@@ -24,6 +24,8 @@ use crate::contexts::agent_execution::model::{
     RawOutputReference, TokenCounts,
 };
 use crate::contexts::agent_execution::service::AgentExecutionPort;
+use crate::contexts::workflow_composition::contracts::ContractFamily;
+use crate::contexts::workflow_composition::payloads::ExecutionPayload;
 use crate::shared::domain::{BackendFamily, FailureClass, ResolvedBackendTarget, SessionPolicy};
 use crate::shared::error::{AppError, AppResult};
 
@@ -459,6 +461,33 @@ impl PreparedCommand {
                         }
                     };
                 let raw_output = codex_raw_transcript(&stdout_text, last_message_text.as_deref());
+
+                // Defense-in-depth against issue #188: codex's `--output-schema`
+                // flag treats the first model JSON message that matches the
+                // schema as the terminal output, ending the turn before tool
+                // calls return. The schema-level fix (validation_evidence
+                // minItems=1 in ExecutionPayload) prevents codex from accepting
+                // the interim message as a match. This check enforces the same
+                // invariant at the ralph-burning side: if an interim payload
+                // somehow reaches us, fail with SchemaValidationFailure rather
+                // than treating it as a successful stage completion.
+                if let Some(reason) =
+                    detect_codex_interim_execution_payload(&request.contract, &parsed_payload)
+                {
+                    self.cleanup_failed_invocation(request, &output).await;
+                    return Err(ProcessBackendAdapter::invocation_failed(
+                        request,
+                        FailureClass::SchemaValidationFailure,
+                        format!(
+                            "codex emitted an interim execution payload before tool calls \
+                             returned ({reason}); the model's turn ended without doing \
+                             actual work. This is GitHub issue #188 — re-running this stage \
+                             should produce a terminal payload as long as the implementer \
+                             does not regress to the gpt-5.5 'emit interim status before \
+                             tool calls' pattern."
+                        ),
+                    ));
+                }
 
                 best_effort_cleanup(Some(schema_path.as_path()), message_path.as_path()).await;
 
@@ -1944,7 +1973,45 @@ pub fn processed_contract_schema_value(
     if backend_family == BackendFamily::Claude {
         wrap_claude_structured_output_schema(schema_value)
     } else {
+        // Codex-only: defeat the interim ExecutionPayload trap (issue #188)
+        // by requiring `validation_evidence` to be non-empty in the schema
+        // codex sees. The shared `ExecutionPayload` schema does NOT carry
+        // this constraint because Claude's semantic validators and
+        // renderers tolerate empty evidence; this is purely a workaround
+        // for codex's `--output-schema` matcher ending the turn on the
+        // first JSON match.
+        if matches!(
+            contract.stage_contract().map(|c| c.family),
+            Some(ContractFamily::Execution)
+        ) {
+            inject_codex_min_validation_evidence(&mut schema_value);
+        }
         schema_value
+    }
+}
+
+/// Walk the codex-bound execution schema and add `minItems: 1` to the
+/// `validation_evidence` array property. Idempotent: if the constraint is
+/// already present (or stronger) it leaves it alone.
+fn inject_codex_min_validation_evidence(schema_value: &mut serde_json::Value) {
+    let Some(properties) = schema_value
+        .get_mut("properties")
+        .and_then(|v| v.as_object_mut())
+    else {
+        return;
+    };
+    let Some(validation_evidence) = properties
+        .get_mut("validation_evidence")
+        .and_then(|v| v.as_object_mut())
+    else {
+        return;
+    };
+    let already = validation_evidence
+        .get("minItems")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if already < 1 {
+        validation_evidence.insert("minItems".to_owned(), serde_json::json!(1));
     }
 }
 
@@ -1973,6 +2040,42 @@ fn unwrap_claude_structured_output_transport_payload(
         }
         other => unwrap_claude_structured_output_payload(other),
     }
+}
+
+/// Detect codex's "interim execution payload" trap (GitHub issue #188).
+///
+/// When codex (`gpt-5.5-high` and `-xhigh`) is invoked with `--output-schema`,
+/// it emits an interim status message before dispatching tool calls — with
+/// every `steps[].status == "intended"` and an empty `validation_evidence`.
+/// If codex's matcher accepts that as a complete schema match, the turn ends
+/// before any work happens.
+///
+/// Returns `Some(reason)` ONLY when the parsed payload matches the canonical
+/// interim shape (every step still in `Intended` AND `validation_evidence`
+/// empty). Mixed-status terminal payloads — e.g. completed steps plus one
+/// deferred `Intended` follow-up with real evidence — are accepted, since the
+/// implementer contract permits that shape (codex-review #188 P1 finding).
+///
+/// Returns `None` when the contract isn't an Execution-family stage or when
+/// the JSON does not deserialize as `ExecutionPayload` (in which case
+/// downstream contract evaluation will produce its own error).
+fn detect_codex_interim_execution_payload(
+    contract: &InvocationContract,
+    payload: &Value,
+) -> Option<String> {
+    let stage = contract.stage_contract()?;
+    if !matches!(stage.family, ContractFamily::Execution) {
+        return None;
+    }
+    let parsed: ExecutionPayload = serde_json::from_value(payload.clone()).ok()?;
+    if !parsed.looks_like_codex_interim_message() {
+        return None;
+    }
+    Some(format!(
+        "validation_evidence is empty AND all {} step(s) are still 'intended' \
+         (canonical issue #188 interim shape)",
+        parsed.steps.len(),
+    ))
 }
 
 fn codex_raw_transcript(stdout: &str, last_message: Option<&str>) -> String {

--- a/src/contexts/workflow_composition/payloads.rs
+++ b/src/contexts/workflow_composition/payloads.rs
@@ -48,12 +48,40 @@ pub struct ReadinessAssessment {
 ///
 /// Requires structured change summaries, intended or completed steps,
 /// validation evidence or plans, and outstanding-risk fields.
+///
+/// The shared schema deliberately does NOT require `validation_evidence` to be
+/// non-empty: that constraint applies only to the codex transport (added at
+/// schema-emit time in `process_backend::processed_contract_schema_value`) so
+/// that Claude execution stages — whose semantic validators and renderers
+/// already tolerate empty validation evidence — are not affected. The codex
+/// constraint exists only to defeat issue #188, where codex's
+/// `--output-schema` flag treats the first matching JSON message (an interim
+/// status emitted before tool calls return) as the terminal output for the
+/// turn.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ExecutionPayload {
     pub change_summary: String,
     pub steps: Vec<ExecutionStep>,
     pub validation_evidence: Vec<String>,
     pub outstanding_risks: Vec<String>,
+}
+
+impl ExecutionPayload {
+    /// Returns `true` when this payload looks like the canonical "interim"
+    /// status message codex emits *before* its tool calls return on
+    /// gpt-5.5-high (GitHub issue #188): empty `validation_evidence` AND
+    /// every step still in `Intended`. A real terminal payload may have a
+    /// mix of `Completed`/`Skipped` and one deferred `Intended` step plus
+    /// real evidence — those are accepted, since the implementer contract
+    /// permits that shape.
+    pub fn looks_like_codex_interim_message(&self) -> bool {
+        self.validation_evidence.is_empty()
+            && !self.steps.is_empty()
+            && self
+                .steps
+                .iter()
+                .all(|step| matches!(step.status, StepStatus::Intended))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -239,4 +267,92 @@ pub enum StagePayload {
     Planning(PlanningPayload),
     Execution(ExecutionPayload),
     Validation(ValidationPayload),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn step(order: u32, status: StepStatus) -> ExecutionStep {
+        ExecutionStep {
+            order,
+            description: "test step".to_owned(),
+            status,
+        }
+    }
+
+    #[test]
+    fn looks_like_codex_interim_message_matches_canonical_issue_188_shape() {
+        // The exact shape codex emits as the *interim* status before tool
+        // calls return: every step intended, validation_evidence empty.
+        let payload = ExecutionPayload {
+            change_summary: "Starting required reading and repository \
+                inspection before editing the documentation file."
+                .to_owned(),
+            steps: vec![step(1, StepStatus::Intended)],
+            validation_evidence: vec![],
+            outstanding_risks: vec![],
+        };
+        assert!(payload.looks_like_codex_interim_message());
+    }
+
+    #[test]
+    fn looks_like_codex_interim_message_rejects_terminal_payload() {
+        // Real terminal: completed/skipped steps with non-empty evidence.
+        let payload = ExecutionPayload {
+            change_summary: "did the thing".to_owned(),
+            steps: vec![step(1, StepStatus::Completed), step(2, StepStatus::Skipped)],
+            validation_evidence: vec!["cargo test passed".to_owned()],
+            outstanding_risks: vec![],
+        };
+        assert!(!payload.looks_like_codex_interim_message());
+    }
+
+    #[test]
+    fn looks_like_codex_interim_message_rejects_terminal_with_one_deferred_step() {
+        // Codex-review #188 P1 finding: the contract permits a
+        // mixed-status terminal payload — completed steps + one intended
+        // follow-up — so long as evidence is present. We MUST NOT misfire
+        // the interim detector on this shape.
+        let payload = ExecutionPayload {
+            change_summary: "did the main work; one item deferred".to_owned(),
+            steps: vec![
+                step(1, StepStatus::Completed),
+                step(2, StepStatus::Intended),
+            ],
+            validation_evidence: vec!["cargo test passed".to_owned()],
+            outstanding_risks: vec![],
+        };
+        assert!(
+            !payload.looks_like_codex_interim_message(),
+            "terminal payload with a deferred step + real evidence must not \
+             be treated as the codex interim shape"
+        );
+    }
+
+    #[test]
+    fn looks_like_codex_interim_message_rejects_payload_with_evidence_even_if_all_intended() {
+        // If the model produced any evidence, this isn't the
+        // tools-haven't-returned-yet interim shape.
+        let payload = ExecutionPayload {
+            change_summary: "explored before deferring".to_owned(),
+            steps: vec![step(1, StepStatus::Intended)],
+            validation_evidence: vec!["read existing file; nothing to change".to_owned()],
+            outstanding_risks: vec![],
+        };
+        assert!(!payload.looks_like_codex_interim_message());
+    }
+
+    #[test]
+    fn looks_like_codex_interim_message_rejects_empty_steps_array() {
+        // Defensive: a payload with no steps at all is not the interim
+        // shape (codex's interim always names at least one intended step).
+        let payload = ExecutionPayload {
+            change_summary: "no work needed".to_owned(),
+            steps: vec![],
+            validation_evidence: vec![],
+            outstanding_risks: vec![],
+        };
+        assert!(!payload.looks_like_codex_interim_message());
+    }
 }

--- a/tests/unit/workflow_panels_test.rs
+++ b/tests/unit/workflow_panels_test.rs
@@ -943,3 +943,61 @@ fn final_review_proposal_payload_schema_has_no_strict_mode_violations() {
         }
     }
 }
+
+#[test]
+fn codex_execution_schema_requires_min_one_validation_evidence_entry() {
+    // Regression for issue #188: codex's `--output-schema` flag treats the
+    // first JSON message that matches the schema as the terminal output
+    // for the turn. Codex on gpt-5.5-high emits an interim status
+    // message before tool calls return, with empty `validation_evidence`
+    // and every step in `Intended`. With a permissive schema, codex
+    // accepts that interim and ends the turn before doing real work.
+    //
+    // The fix is codex-specific: when emitting the schema for a codex
+    // invocation, ralph-burning injects `minItems: 1` on
+    // `validation_evidence`. This regression test asserts:
+    //   1. The constraint IS present for codex execution stages.
+    //   2. The constraint is NOT present for Claude execution stages
+    //      (Claude's semantic validators tolerate empty evidence).
+    use ralph_burning::adapters::process_backend::processed_contract_schema_value;
+    use ralph_burning::contexts::agent_execution::model::InvocationContract;
+    use ralph_burning::shared::domain::BackendFamily;
+
+    for stage_id in [
+        StageId::Implementation,
+        StageId::PlanAndImplement,
+        StageId::ApplyFixes,
+    ] {
+        let contract = InvocationContract::Stage(
+            ralph_burning::contexts::workflow_composition::contracts::contract_for_stage(stage_id),
+        );
+
+        let codex_schema = processed_contract_schema_value(&contract, BackendFamily::Codex);
+        let codex_min = codex_schema
+            .pointer("/properties/validation_evidence/minItems")
+            .and_then(|v| v.as_u64());
+        assert_eq!(
+            codex_min,
+            Some(1),
+            "Codex schema for {stage_id:?} must inject minItems=1 on \
+             validation_evidence (issue #188 workaround). Got: {codex_schema:#}"
+        );
+
+        let claude_schema = processed_contract_schema_value(&contract, BackendFamily::Claude);
+        // Claude wraps the payload in `{ data: ... }`, so look one level deeper.
+        let claude_min = claude_schema
+            .pointer("/properties/data/properties/validation_evidence/minItems")
+            .and_then(|v| v.as_u64())
+            .or_else(|| {
+                claude_schema
+                    .pointer("/properties/validation_evidence/minItems")
+                    .and_then(|v| v.as_u64())
+            });
+        assert_eq!(
+            claude_min, None,
+            "Claude schema for {stage_id:?} must NOT carry the codex-only \
+             minItems=1 workaround — Claude tolerates empty validation_evidence. \
+             Got: {claude_schema:#}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #188.

## Summary

Codex's `--output-schema` flag treats the first model JSON message that matches the schema as the terminal output for the turn — codex ends the turn at that point, before any tool call returns. On `gpt-5.5-high` (and `-xhigh`), codex emits an interim status message ahead of its tool calls with all `steps[].status == "intended"` and an empty `validation_evidence`. With the previous schema, that interim payload matched, codex's turn ended, and ralph-burning saw exit code 101 + truncated stderr. After 5 retries the run failed with `failure_class: transport_failure`.

## Two-layer fix

1. **Codex-only schema constraint.** When emitting the schema for a codex Execution-family invocation, ralph-burning injects `minItems: 1` on `validation_evidence` (in `process_backend::processed_contract_schema_value`). Codex's matcher then refuses the interim payload, so codex keeps producing tool calls until at least one validation evidence string is present. The shared `ExecutionPayload` schema is left alone — Claude's semantic validators tolerate empty evidence and would break under the new constraint.

2. **Defense-in-depth detector.** `process_backend.rs::finish()` for the codex decoder now calls `detect_codex_interim_execution_payload()`, which matches ONLY the canonical interim shape (every step still in `Intended` AND `validation_evidence` empty). Mixed-status terminal payloads — completed steps plus one deferred `Intended` follow-up with real evidence — are accepted. If the canonical interim slips through, the invocation fails with `SchemaValidationFailure` and a diagnostic that names the issue.

## Codex-review-loop log

Pass 1 found two real issues:
- **P1**: detector was too broad, would misfire on terminal payloads with one deferred `Intended` step. Fixed by tightening to the canonical shape (every step intended + empty evidence) via new `ExecutionPayload::looks_like_codex_interim_message()`.
- **P2**: `minItems: 1` on the shared schema would break Claude. Fixed by moving the constraint to `processed_contract_schema_value` and applying it only when emitting for codex.

Pass 2 returned no findings.

## Tests

- 5 inline unit tests on `ExecutionPayload::looks_like_codex_interim_message` covering: canonical interim shape, terminal completed/skipped, terminal with deferred follow-up + evidence, all-intended-with-evidence, empty steps array.
- 1 regression test in `workflow_panels_test` asserting the codex schema carries `minItems: 1` on `validation_evidence` AND the Claude schema does not.

## Test plan

- [x] `nix develop -c cargo test --features test-stub --locked` passes
- [x] `nix develop -c cargo clippy --locked --features test-stub -- -D warnings` clean
- [x] `nix develop -c cargo fmt --check` clean
- [x] `nix build` succeeds
- [ ] CI green
- [ ] Codex bot review on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)