### PR TITLE
fix(codex): broaden interim detector + tighten Execution forward-progress contract (#188 reopen)

### DIFF
--- a/src/adapters/process_backend.rs
+++ b/src/adapters/process_backend.rs
@@ -481,10 +481,11 @@ impl PreparedCommand {
                         format!(
                             "codex emitted an interim execution payload before tool calls \
                              returned ({reason}); the model's turn ended without doing \
-                             actual work. This is GitHub issue #188 — re-running this stage \
-                             should produce a terminal payload as long as the implementer \
-                             does not regress to the gpt-5.5 'emit interim status before \
-                             tool calls' pattern."
+                             actual work. This is GitHub issue #188. Retries from a fresh \
+                             codex session generally reproduce the same shape, so the \
+                             practical workaround is to override the implementer backend: \
+                             `ralph-burning config set workflow.implementer_backend claude`. \
+                             Tracking session-resume-aware retry at issue #188 follow-up."
                         ),
                     ));
                 }

--- a/src/contexts/workflow_composition/contracts.rs
+++ b/src/contexts/workflow_composition/contracts.rs
@@ -208,6 +208,7 @@ impl StageContract {
                 }
             }
             StagePayload::Execution(p) => {
+                use crate::contexts::workflow_composition::payloads::StepStatus;
                 let mut errors = Vec::new();
                 if p.change_summary.trim().is_empty() {
                     errors.push("change_summary must not be empty".to_string());
@@ -219,6 +220,25 @@ impl StageContract {
                     if step.description.is_empty() {
                         errors.push(format!("steps[{i}].description must not be empty"));
                     }
+                }
+                // Forward-progress check: a terminal Execution payload must
+                // include at least one Completed or Skipped step. An all-
+                // `Intended` payload describes a plan, not a result, so it
+                // cannot be the end of a turn. This requirement was added to
+                // align the contract with the codex interim-message
+                // detector (GitHub issue #188); both backends are held to
+                // the same forward-progress invariant for execution stages.
+                let has_progress = p
+                    .steps
+                    .iter()
+                    .any(|s| matches!(s.status, StepStatus::Completed | StepStatus::Skipped));
+                if !p.steps.is_empty() && !has_progress {
+                    errors.push(
+                        "steps must contain at least one item with status \
+                         'completed' or 'skipped' (forward-progress invariant; \
+                         see GitHub issue #188)"
+                            .to_string(),
+                    );
                 }
                 if !errors.is_empty() {
                     return Err(ContractError::DomainValidation {

--- a/src/contexts/workflow_composition/payloads.rs
+++ b/src/contexts/workflow_composition/payloads.rs
@@ -67,16 +67,27 @@ pub struct ExecutionPayload {
 }
 
 impl ExecutionPayload {
-    /// Returns `true` when this payload looks like the canonical "interim"
-    /// status message codex emits *before* its tool calls return on
-    /// gpt-5.5-high (GitHub issue #188): empty `validation_evidence` AND
-    /// every step still in `Intended`. A real terminal payload may have a
-    /// mix of `Completed`/`Skipped` and one deferred `Intended` step plus
-    /// real evidence — those are accepted, since the implementer contract
-    /// permits that shape.
+    /// Returns `true` when this payload looks like the codex "interim"
+    /// status message emitted *before* tool calls return on gpt-5.5-high
+    /// (GitHub issue #188).
+    ///
+    /// The signal: every step is still in `Intended`. We deliberately do
+    /// NOT also require `validation_evidence` to be empty: the original
+    /// PR #189 detector did, but issue #188 was reopened after codex was
+    /// observed satisfying the codex-only `minItems: 1` schema constraint
+    /// with a single placeholder string (e.g. "Workspace: …; task accepted
+    /// for execution.") while keeping every step intended. A bogus-but-
+    /// schema-conformant evidence string does not change the substantive
+    /// fact: nothing has been completed or skipped yet, so the turn cannot
+    /// be terminal.
+    ///
+    /// A real terminal payload always has at least one `Completed` or
+    /// `Skipped` step (the implementer contract requires forward
+    /// progress). A mixed-status terminal payload — completed steps plus
+    /// one deferred `Intended` follow-up — still passes because not every
+    /// step is intended.
     pub fn looks_like_codex_interim_message(&self) -> bool {
-        self.validation_evidence.is_empty()
-            && !self.steps.is_empty()
+        !self.steps.is_empty()
             && self
                 .steps
                 .iter()
@@ -331,16 +342,29 @@ mod tests {
     }
 
     #[test]
-    fn looks_like_codex_interim_message_rejects_payload_with_evidence_even_if_all_intended() {
-        // If the model produced any evidence, this isn't the
-        // tools-haven't-returned-yet interim shape.
+    fn looks_like_codex_interim_message_matches_issue_188_reopen_shape_with_placeholder_evidence() {
+        // Issue #188 reopen: codex satisfies the codex-only minItems=1
+        // schema constraint with a placeholder evidence string while
+        // keeping every step in Intended. The placeholder describes the
+        // workspace, not actual validation work. Original PR #189 detector
+        // missed this because it required validation_evidence to be empty.
         let payload = ExecutionPayload {
-            change_summary: "explored before deferring".to_owned(),
-            steps: vec![step(1, StepStatus::Intended)],
-            validation_evidence: vec!["read existing file; nothing to change".to_owned()],
+            change_summary: "Starting the documentation review/edit task".to_owned(),
+            steps: vec![
+                step(1, StepStatus::Intended),
+                step(2, StepStatus::Intended),
+                step(3, StepStatus::Intended),
+            ],
+            validation_evidence: vec![
+                "Workspace: /home/user/work; task accepted for execution.".to_owned()
+            ],
             outstanding_risks: vec![],
         };
-        assert!(!payload.looks_like_codex_interim_message());
+        assert!(
+            payload.looks_like_codex_interim_message(),
+            "all-intended steps + bogus placeholder evidence is the canonical \
+             issue #188 reopen shape — must be detected"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Addresses #188 reopen.

## Summary

After PR #189 landed, issue #188 was reopened: codex bypasses the codex-only `minItems: 1` schema constraint by emitting a single placeholder evidence string (e.g. `"Workspace: …; task accepted for execution."`) while keeping every `steps[].status == Intended`. The original `looks_like_codex_interim_message` detector required `validation_evidence` to be empty too, so this placeholder shape slipped through.

## Two-part fix

1. **Detector**: drop the empty-evidence requirement. Match purely on "every step still in `Intended`". The implementer contract requires forward progress — a real terminal payload always has at least one `Completed` or `Skipped` step. The mixed-status case (completed + one deferred Intended + real evidence) still passes.

2. **Contract**: tighten `ContractFamily::Execution::validate_semantics` to require at least one `Completed` or `Skipped` step. An all-`Intended` payload describes a plan, not a result. Both backends (codex and Claude) are now held to the same forward-progress invariant — addresses the codex-review pass-1 P2 finding that all-Intended was contract-valid.

3. **Failure message**: points at the practical workaround (`config set workflow.implementer_backend claude`) since the deeper session-resume fix is tracked separately as `ralph-burning-i59`.

## Codex-review-loop log

- Pass 1 P2: detector might reject contract-valid terminal payloads with all-Intended steps. Addressed by tightening `validate_semantics` so all-Intended is now contract-invalid for both backends.
- Pass 2 P1: detector failure persists across retries because no session_id is preserved on schema-validation failure — codex starts fresh each retry and reproduces the interim. Acknowledged: the deeper fix needs session-resume-aware retry. Filed as `ralph-burning-i59`. The current PR makes the failure mode visible and clearly diagnoseable, plus points operators at the working workaround.

## Tests

- 5 inline unit tests on `looks_like_codex_interim_message`, including the canonical issue-#188 reopen shape with placeholder evidence.

## Test plan

- [x] `nix develop -c cargo test --features test-stub --locked` passes
- [x] `nix develop -c cargo clippy --locked -- -D warnings` clean
- [x] `nix develop -c cargo fmt --check` clean
- [ ] CI green
- [ ] Codex bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)