### PR TITLE
fix(codex): require at least one completed/skipped step in codex schema (#188 third comment)

### DIFF
--- a/src/adapters/process_backend.rs
+++ b/src/adapters/process_backend.rs
@@ -1975,17 +1975,26 @@ pub fn processed_contract_schema_value(
         wrap_claude_structured_output_schema(schema_value)
     } else {
         // Codex-only: defeat the interim ExecutionPayload trap (issue #188)
-        // by requiring `validation_evidence` to be non-empty in the schema
-        // codex sees. The shared `ExecutionPayload` schema does NOT carry
-        // this constraint because Claude's semantic validators and
-        // renderers tolerate empty evidence; this is purely a workaround
-        // for codex's `--output-schema` matcher ending the turn on the
-        // first JSON match.
+        // by tightening the schema codex's `--output-schema` matcher sees.
+        // Two constraints, both injected here so Claude's shared schema
+        // (which has different validation semantics) is unaffected:
+        //
+        // 1. `validation_evidence` requires `minItems: 1`. Started in PR
+        //    #189; codex bypassed it with a placeholder string.
+        // 2. `steps` requires `contains` + `minContains: 1` matching at
+        //    least one step with `status ∈ {completed, skipped}`. This
+        //    is the actual fix for the issue #188 reopen: the matcher
+        //    now refuses any all-`intended` payload, so codex must
+        //    actually progress at least one step (which requires running
+        //    a tool) before its JSON conforms. Per the user's repro
+        //    comment on the issue, codex's matcher supports
+        //    `contains`/`minContains` (JSON Schema draft 6+).
         if matches!(
             contract.stage_contract().map(|c| c.family),
             Some(ContractFamily::Execution)
         ) {
             inject_codex_min_validation_evidence(&mut schema_value);
+            inject_codex_steps_forward_progress(&mut schema_value);
         }
         schema_value
     }
@@ -2013,6 +2022,85 @@ fn inject_codex_min_validation_evidence(schema_value: &mut serde_json::Value) {
         .unwrap_or(0);
     if already < 1 {
         validation_evidence.insert("minItems".to_owned(), serde_json::json!(1));
+    }
+}
+
+/// Walk the codex-bound execution schema and add a `contains` +
+/// `minContains: 1` constraint to the `steps` array, requiring at least
+/// one entry with `status ∈ {completed, skipped}`. This forces codex's
+/// `--output-schema` matcher to refuse all-`intended` payloads at the
+/// schema layer, before the matcher would otherwise end the turn on the
+/// first JSON match (GitHub issue #188).
+///
+/// Idempotent: if a stricter constraint is already present, it's left
+/// alone.
+fn inject_codex_steps_forward_progress(schema_value: &mut serde_json::Value) {
+    let Some(properties) = schema_value
+        .get_mut("properties")
+        .and_then(|v| v.as_object_mut())
+    else {
+        return;
+    };
+    let Some(steps) = properties.get_mut("steps").and_then(|v| v.as_object_mut()) else {
+        return;
+    };
+    if !steps.contains_key("contains") {
+        // Build the `contains` subschema from `steps.items` so it matches
+        // the same step shape (`order`, `description`, `status`,
+        // `additionalProperties: false`, every property in `required`)
+        // and only narrows `status` to {completed, skipped}.
+        //
+        // Why clone `items` instead of hand-writing the subschema:
+        //   - codex-review #194 P1 (first round): strict-mode requires
+        //     every object subschema to carry `additionalProperties: false`
+        //     and list every property in `required`. A hand-written subset
+        //     is easy to drift out of sync with `ExecutionStep`.
+        //   - codex-review #194 P1 (second round): a hand-written subset
+        //     with `additionalProperties: false` made the contains subschema
+        //     unsatisfiable because real steps also carry `order` and
+        //     `description` — no actual step could match.
+        // Cloning the items schema gives us the exact shape codex already
+        // expects step objects to take, then we override only `status`.
+        let contains_schema = steps.get("items").cloned().and_then(|items_value| {
+            let mut subschema = items_value;
+            let status = subschema
+                .get_mut("properties")
+                .and_then(|v| v.as_object_mut())
+                .and_then(|m| m.get_mut("status"));
+            let status_obj = status.and_then(|v| v.as_object_mut())?;
+            status_obj.insert(
+                "enum".to_owned(),
+                serde_json::json!(["completed", "skipped"]),
+            );
+            Some(subschema)
+        });
+
+        if let Some(contains_schema) = contains_schema {
+            steps.insert("contains".to_owned(), contains_schema);
+        } else {
+            // Fallback: if we couldn't derive from items (unexpected
+            // schema shape), inject a hand-written full-step subschema
+            // so the constraint still applies.
+            let mut subschema = serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "order": { "type": "integer", "format": "uint32", "minimum": 0 },
+                    "description": { "type": "string" },
+                    "status": { "enum": ["completed", "skipped"] }
+                },
+                "required": ["order", "description", "status"],
+                "additionalProperties": false,
+            });
+            enforce_strict_mode_schema(&mut subschema);
+            steps.insert("contains".to_owned(), subschema);
+        }
+    }
+    let already = steps
+        .get("minContains")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if already < 1 {
+        steps.insert("minContains".to_owned(), serde_json::json!(1));
     }
 }
 

--- a/tests/unit/workflow_panels_test.rs
+++ b/tests/unit/workflow_panels_test.rs
@@ -945,6 +945,136 @@ fn final_review_proposal_payload_schema_has_no_strict_mode_violations() {
 }
 
 #[test]
+fn codex_execution_schema_requires_min_one_completed_or_skipped_step() {
+    // Issue #188 (third comment after PR #193): the runtime detector and
+    // contract tightening were both correct, but codex never reaches them.
+    // Codex's `--output-schema` matcher accepts an all-Intended payload
+    // because the schema only enumerates the status values without
+    // requiring any to be completed/skipped. Codex ends the turn → exit
+    // code 101 → ralph classifies as transport_failure → retries → fail.
+    //
+    // The fix is at the schema layer: inject `contains` + `minContains: 1`
+    // matching at least one step with status ∈ {completed, skipped}.
+    // Codex's matcher then refuses any all-Intended payload upfront, so
+    // codex must actually progress before its JSON conforms.
+    use ralph_burning::adapters::process_backend::processed_contract_schema_value;
+    use ralph_burning::contexts::agent_execution::model::InvocationContract;
+    use ralph_burning::shared::domain::BackendFamily;
+
+    for stage_id in [
+        StageId::Implementation,
+        StageId::PlanAndImplement,
+        StageId::ApplyFixes,
+    ] {
+        let contract = InvocationContract::Stage(
+            ralph_burning::contexts::workflow_composition::contracts::contract_for_stage(stage_id),
+        );
+
+        let codex_schema = processed_contract_schema_value(&contract, BackendFamily::Codex);
+        let steps = codex_schema
+            .pointer("/properties/steps")
+            .unwrap_or_else(|| panic!("steps property present in codex schema for {stage_id:?}"));
+        let contains = steps
+            .get("contains")
+            .unwrap_or_else(|| panic!("steps.contains present in codex schema for {stage_id:?}"));
+        let allowed_statuses = contains
+            .pointer("/properties/status/enum")
+            .and_then(|v| v.as_array())
+            .unwrap_or_else(|| {
+                panic!(
+                    "steps.contains.properties.status.enum present in codex schema for {stage_id:?}"
+                )
+            });
+        let allowed: Vec<&str> = allowed_statuses.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            allowed.contains(&"completed") && allowed.contains(&"skipped"),
+            "steps.contains.properties.status.enum must include completed AND skipped \
+             for {stage_id:?}; got {allowed:?}"
+        );
+        assert_eq!(
+            steps.get("minContains").and_then(|v| v.as_u64()),
+            Some(1),
+            "steps.minContains must be 1 for {stage_id:?} — required to defeat \
+             issue #188 codex matcher early-termination. Got: {steps:#}"
+        );
+
+        // codex-review #194 P1: the injected `contains` subschema must
+        // carry the strict-mode object invariants too. OpenAI rejects any
+        // object subschema in a strict-mode payload that doesn't have
+        // `additionalProperties: false` and `required` listing every
+        // property.
+        assert_eq!(
+            contains.get("additionalProperties"),
+            Some(&serde_json::json!(false)),
+            "steps.contains must carry additionalProperties:false for \
+             {stage_id:?} (strict-mode requirement). Got: {contains:#}"
+        );
+        let contains_required = contains
+            .get("required")
+            .and_then(|v| v.as_array())
+            .unwrap_or_else(|| {
+                panic!(
+                    "steps.contains.required must be present for {stage_id:?}; got: {contains:#}"
+                )
+            });
+        let required_names: Vec<&str> = contains_required
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(
+            required_names.contains(&"status"),
+            "steps.contains.required must include 'status' for {stage_id:?}; got: {required_names:?}"
+        );
+
+        // codex-review #194 P1 (second round): the contains subschema
+        // must include all properties that `steps.items` defines too,
+        // otherwise `additionalProperties: false` makes it unsatisfiable
+        // for real step objects (which carry `order`, `description`,
+        // `status` together). The contains constraint only narrows the
+        // status enum — it must accept the same field shape as items.
+        let items = codex_schema
+            .pointer("/properties/steps/items")
+            .unwrap_or_else(|| panic!("steps.items must be present for {stage_id:?}"));
+        let items_props = items
+            .pointer("/properties")
+            .and_then(|v| v.as_object())
+            .unwrap_or_else(|| panic!("steps.items.properties must be present for {stage_id:?}"));
+        let contains_props = contains
+            .pointer("/properties")
+            .and_then(|v| v.as_object())
+            .unwrap_or_else(|| {
+                panic!("steps.contains.properties must be present for {stage_id:?}")
+            });
+        for items_field in items_props.keys() {
+            assert!(
+                contains_props.contains_key(items_field),
+                "steps.contains.properties must include '{items_field}' for \
+                 {stage_id:?} (matches items.properties so the contains \
+                 subschema is satisfiable under additionalProperties:false). \
+                 Got contains: {contains:#}"
+            );
+            assert!(
+                required_names.contains(&items_field.as_str()),
+                "steps.contains.required must include '{items_field}' for \
+                 {stage_id:?} (mirrors items.required for strict-mode \
+                 compatibility). Got: {required_names:?}"
+            );
+        }
+
+        // Claude schema must NOT carry the codex-only constraint.
+        let claude_schema = processed_contract_schema_value(&contract, BackendFamily::Claude);
+        let claude_steps_contains = claude_schema
+            .pointer("/properties/data/properties/steps/contains")
+            .or_else(|| claude_schema.pointer("/properties/steps/contains"));
+        assert!(
+            claude_steps_contains.is_none(),
+            "Claude schema for {stage_id:?} must NOT carry the codex-only \
+             contains constraint. Got: {claude_schema:#}"
+        );
+    }
+}
+
+#[test]
 fn codex_execution_schema_requires_min_one_validation_evidence_entry() {
     // Regression for issue #188: codex's `--output-schema` flag treats the
     // first JSON message that matches the schema as the terminal output


### PR DESCRIPTION
Addresses issue #188 (third comment).

## Summary

PR #189 added codex-only `validation_evidence: minItems=1`. PR #193 broadened the runtime detector and tightened the Execution contract. The reporter confirmed both were correct *but neither helped in practice*: codex's `--output-schema` matcher accepts an all-Intended payload because the schema only enumerates status values, codex ends the turn, exits 101, and ralph classifies it as `transport_failure` BEFORE the runtime detector ever runs.

This PR is the schema-level fix the reporter requested:

```json
"steps": {
  "type": "array",
  "items": { ... },
  "contains": {
    "type": "object",
    "properties": { "status": { "enum": ["completed", "skipped"] } },
    "required": ["status"]
  },
  "minContains": 1
}
```

Injected only on the codex branch of `processed_contract_schema_value` (alongside the existing `validation_evidence: minItems=1`), so Claude's shared schema is unaffected. Codex's matcher now refuses any all-Intended payload upfront — the model must actually progress at least one step (running a tool) before its JSON conforms.

## Lineage

- PR #189 (merged): `validation_evidence: minItems=1`. Codex bypassed with a placeholder string.
- PR #193 (merged): runtime detector + contract tightening. Never runs because codex exits before parsing.
- This PR: schema-level forward-progress constraint that gates codex's matcher itself.
- `ralph-burning-i59` (separate): session-resume retry path, still useful as defense-in-depth.

## Test plan

- [x] `nix develop -c cargo test --features test-stub --locked` passes
- [x] `nix develop -c cargo clippy --locked --features test-stub -- -D warnings` clean
- [x] `nix develop -c cargo fmt --check` clean
- [x] New regression test asserts the codex schema carries `contains` + `minContains: 1` AND Claude schema does not
- [ ] CI green
- [ ] Codex bot review
- [ ] Reporter confirmation that the master-t9j0 reproducer is unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)