### PR TITLE
fix(codex): drop --json from execution stages to avoid CLI broken-pipe panic (#188 regression)

### DIFF
--- a/src/adapters/process_backend.rs
+++ b/src/adapters/process_backend.rs
@@ -422,12 +422,14 @@ impl PreparedCommand {
                             ));
                         }
                     };
-                    copy_codex_transcript_into_history(
-                        &request.project_root,
-                        &request.invocation_id,
-                        &output.stdout,
-                    )
-                    .await;
+                    // Transcript copying via `--json` was reverted to fix
+                    // codex's broken-pipe panic regression (see
+                    // `codex_new_session_args`). The forensic transcript
+                    // can be reintroduced by reading codex's own session
+                    // JSONL at `~/.codex/sessions/.../rollout-*.jsonl`,
+                    // which is independent of stdout streaming. Stdout
+                    // here is now a short human-readable summary, which
+                    // we don't need to copy as a transcript.
                     let payload = synthesize_codex_execution_payload(last_message_text.as_deref());
                     (payload, last_message_text)
                 } else {
@@ -1534,17 +1536,24 @@ impl ProcessBackendAdapter {
         if let Some(schema_path) = schema_path {
             args.push("--output-schema".to_owned());
             args.push(schema_path.to_string_lossy().into_owned());
-        } else {
-            // Issue #188 codex execution path: `--output-schema` is dropped
-            // so the schema-driven early-termination cannot trigger. Pair
-            // this with `--json` so stdout becomes a complete NDJSON event
-            // transcript (model messages, tool calls, tool results) — that
-            // stream is what we copy verbatim into history/transcripts as
-            // the forensic record. Without `--json`, codex emits a
-            // human-readable summary on stdout instead, which is not
-            // adequate as an event log.
-            args.push("--json".to_owned());
         }
+        // Note: PR #196 originally paired the schema-less Execution path
+        // with `--json` so stdout would be a complete NDJSON event
+        // transcript. That triggered a regression in codex 0.125.0:
+        // codex's `--json` mode panics on broken-pipe writes to stdout
+        // (`failed printing to stdout: Broken pipe (os error 32)`),
+        // reproducible without ralph by piping through `head -n 1`.
+        // The panic is in codex's stdio handler, not in ralph; codex
+        // CLI 0.125.0 doesn't install a SIGPIPE handler the way
+        // well-behaved tools do.
+        //
+        // We can't fix codex from here, so we just don't use `--json`.
+        // Codex still emits a human-readable summary on stdout and
+        // populates `--output-last-message`; the synthesizer (PR #196)
+        // works with either. The forensic transcript can be reintroduced
+        // later by reading codex's session JSONL file from
+        // `~/.codex/sessions/.../rollout-*.jsonl` post-exit, which is
+        // independent of stdout streaming.
         args.extend([
             "--output-last-message".to_owned(),
             message_path.to_string_lossy().into_owned(),
@@ -1581,10 +1590,9 @@ impl ProcessBackendAdapter {
         if let Some(schema_path) = schema_path {
             args.push("--output-schema".to_owned());
             args.push(schema_path.to_string_lossy().into_owned());
-        } else {
-            // See `codex_new_session_args` for the `--json` rationale.
-            args.push("--json".to_owned());
         }
+        // See `codex_new_session_args` for why `--json` is intentionally
+        // omitted on the schema-less execution path.
         args.extend([
             "--output-last-message".to_owned(),
             message_path.to_string_lossy().into_owned(),
@@ -2101,43 +2109,6 @@ fn synthesize_codex_execution_payload(last_message_text: Option<&str>) -> Value 
         "validation_evidence": [],
         "outstanding_risks": [],
     })
-}
-
-/// Copy the codex stdout NDJSON event transcript verbatim into
-/// `<project_root>/history/transcripts/codex-<invocation_id>.jsonl` so the
-/// run history is self-contained for forensics.
-///
-/// This is invoked only on the codex Execution synth path, which passes
-/// `--json` to codex (see `codex_new_session_args`). With `--json`, codex
-/// emits one JSON event per stdout line covering model messages, tool
-/// calls, and tool results — the same forensic content as the codex
-/// session rollout file at `~/.codex/sessions/...rollout-*.jsonl`, but
-/// captured directly from the child process so we don't have to discover
-/// the rollout path. Best-effort: failures are logged but do not fail the
-/// invocation.
-async fn copy_codex_transcript_into_history(
-    project_root: &Path,
-    invocation_id: &str,
-    stdout: &[u8],
-) {
-    let dir = project_root.join("history/transcripts");
-    if let Err(error) = tokio::fs::create_dir_all(&dir).await {
-        tracing::warn!(
-            invocation_id,
-            error = %error,
-            "failed to create history/transcripts directory; skipping codex transcript copy"
-        );
-        return;
-    }
-    let path = dir.join(format!("codex-{invocation_id}.jsonl"));
-    if let Err(error) = tokio::fs::write(&path, stdout).await {
-        tracing::warn!(
-            invocation_id,
-            path = %path.display(),
-            error = %error,
-            "failed to write codex transcript into history"
-        );
-    }
 }
 
 fn codex_raw_transcript(stdout: &str, last_message: Option<&str>) -> String {

--- a/tests/unit/process_backend_test.rs
+++ b/tests/unit/process_backend_test.rs
@@ -2975,13 +2975,17 @@ async fn codex_execution_stage_args_do_not_include_output_schema() {
         "codex Execution-family invocations should still pass \
          --output-last-message; got: {args:?}"
     );
-    // With --output-schema dropped, codex must be invoked with --json so
-    // stdout becomes a complete NDJSON event transcript that we can
-    // preserve verbatim into history/transcripts (issue #188 amendment).
+    // PR #196 originally added --json to capture an NDJSON event
+    // transcript from stdout, but codex 0.125.0 panics on broken-pipe
+    // writes in --json mode (`failed printing to stdout: Broken pipe`),
+    // reproducible with `head -n 1`. We can't fix codex from here, so
+    // we don't pass --json. Forensic transcripts can be reintroduced via
+    // codex's own session JSONL at `~/.codex/sessions/.../rollout-*.jsonl`,
+    // which is independent of stdout streaming.
     assert!(
-        args.iter().any(|a| a == "--json"),
-        "codex Execution-family invocations must pass --json so stdout is a \
-         complete event transcript; got: {args:?}"
+        !args.iter().any(|a| a == "--json"),
+        "codex Execution-family invocations must NOT pass --json (avoids \
+         the codex 0.125.0 broken-pipe panic regression); got: {args:?}"
     );
 
     // The schema temp file should never have been written for the
@@ -2999,10 +3003,10 @@ async fn codex_execution_stage_args_do_not_include_output_schema() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn codex_planning_stage_does_not_pass_json_flag() {
-    // The --json flag is reserved for the codex Execution synth path
-    // (which has no --output-schema). Planning/Validation stages still
-    // use --output-schema and must NOT receive --json — adding it would
-    // break the existing single-value stdout fallback path.
+    // No codex invocation passes --json after the broken-pipe regression
+    // fix; Planning still passes --output-schema (matches its structured-
+    // output expectation). Asserting --json is absent on Planning is a
+    // sanity check that the schema-bearing path is unaffected.
     let bin_dir = tempdir().expect("create bin dir");
     let _env_lock = lock_path_mutex();
     let _path_guard = PathGuard::prepend(bin_dir.path());
@@ -3031,13 +3035,18 @@ async fn codex_planning_stage_does_not_pass_json_flag() {
     );
     assert!(
         !args.iter().any(|a| a == "--json"),
-        "Planning-family codex invocations must NOT pass --json (only the \
-         issue #188 Execution synth path uses --json); got: {args:?}"
+        "Planning-family codex invocations must NOT pass --json; got: {args:?}"
     );
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn codex_execution_stage_synthesizes_payload_and_copies_transcript() {
+async fn codex_execution_stage_synthesizes_payload() {
+    // Verifies the issue #188 synth path: ralph constructs an
+    // ExecutionPayload from codex's last-message text rather than asking
+    // codex for structured output. The transcript-copying assertion was
+    // removed when we dropped --json (codex 0.125.0 panics on broken
+    // pipe in --json mode); transcript capture via codex's session JSONL
+    // file is tracked as a follow-up.
     let bin_dir = tempdir().expect("create bin dir");
     let _env_lock = lock_path_mutex();
     let _path_guard = PathGuard::prepend(bin_dir.path());
@@ -3047,9 +3056,7 @@ async fn codex_execution_stage_synthesizes_payload_and_copies_transcript() {
     let last_message = "Edited src/foo.rs and added tests; cargo test passed.";
     let payload_file = request.working_dir.join("codex-payload.json");
     fs::write(&payload_file, last_message).expect("write last-message text");
-    let stdout_text = "{\"type\":\"event\",\"name\":\"exec_command\",\"exit_code\":0}\n\
-{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":42}}";
-    write_fake_codex_with_stdout(bin_dir.path(), &payload_file, stdout_text);
+    write_fake_codex(bin_dir.path(), &payload_file);
 
     let adapter = ProcessBackendAdapter::new();
     let envelope = adapter
@@ -3081,40 +3088,6 @@ async fn codex_execution_stage_synthesizes_payload_and_copies_transcript() {
         0,
         "synthesized payload validation_evidence should be empty (the \
          git diff is the load-bearing record)"
-    );
-
-    // Transcript copied verbatim to history/transcripts. With --json,
-    // stdout is a complete NDJSON event transcript: each non-blank line
-    // must parse as a JSON object so the file is genuinely usable as a
-    // forensic event log (rather than being a human-readable summary
-    // dump that happens to contain a JSON line or two).
-    let transcript_path = request
-        .project_root
-        .join("history/transcripts")
-        .join(format!("codex-{}.jsonl", request.invocation_id));
-    let transcript_contents =
-        fs::read_to_string(&transcript_path).expect("transcript file should exist");
-    assert!(
-        transcript_contents.contains("turn.completed"),
-        "transcript should contain codex stdout events; got: \
-         {transcript_contents:?}"
-    );
-    let event_count = transcript_contents
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .map(|line| {
-            serde_json::from_str::<serde_json::Value>(line).unwrap_or_else(|error| {
-                panic!(
-                    "every transcript line must be valid JSON (--json mode); \
-                     line was {line:?}, error: {error}"
-                )
-            })
-        })
-        .count();
-    assert_eq!(
-        event_count, 2,
-        "transcript should contain exactly the two NDJSON events written \
-         by the fake codex; got: {transcript_contents:?}"
     );
 }
 


### PR DESCRIPTION
Fixes the regression on #188 that landed with PR #196.

## Summary

PR #196 paired the schema-less codex Execution path with `--json` to capture an NDJSON event transcript from stdout. That triggered a regression: codex CLI 0.125.0 doesn't install a SIGPIPE handler, so when its stdout consumer closes early (or the kernel pipe buffer fills), codex panics with:

```
failed printing to stdout: Broken pipe (os error 32)
```

Every codex execution invocation post-#196 hit this within 1-4s — no model messages, no tool calls. Reported at #188 with a CLI-only reproducer:

```
echo "say hi" | codex exec --json --dangerously-bypass-approvals-and-sandbox - -m gpt-5.5 | head -n 1
PIPESTATUS=0 101 0
```

## Fix

Drop `--json` for codex Execution stages. Codex still emits the last-message text via `--output-last-message <path>` independent of `--json`, so the synthesizer (`synthesize_codex_execution_payload`) works unchanged. The forensic transcript path `<project>/history/transcripts/codex-*.jsonl` no longer gets populated; that capability is tracked as `ralph-burning-b57` (reintroduce via codex's own session JSONL at `~/.codex/sessions/.../rollout-*.jsonl`, independent of stdout streaming).

## Tradeoffs / explicit losses

Per the codex consultation on this approach:
- **Transcript loss**: `<project>/history/transcripts/codex-<id>.jsonl` is no longer written for Execution stages. Stderr capture (which carries the actual error text on codex panics) is unchanged and is now the main forensic stream.
- **No downstream code/tests/docs require the transcript path** for successful Execution runs — verified.
- **Follow-up tracked**: `ralph-burning-b57` for the durable replacement (session JSONL copying); `ralph-burning-c1w` for an upstream codex bug report.

## Side effects

- Removes the now-unused `copy_codex_transcript_into_history` helper (was the dead-code source of a fresh clippy warning).
- Three tests updated:
  - `codex_execution_stage_synthesizes_payload_and_copies_transcript` → renamed `..._synthesizes_payload`, transcript-copy assertion removed.
  - `codex_planning_stage_does_not_pass_json_flag` — comment updated; assertion unchanged.
  - The Execution-args negative-assertion now requires `--json` is absent (was: required `--json` is present).

## Codex-design-consultation lineage

Asked gpt-5.5-xhigh which of five approaches was best (drop `--json`, drain-harden, session-JSONL-copy, shell shim ignoring SIGPIPE, upstream codex fix). Recommendation: option 1 (drop `--json`) is the smallest deterministic rollback, preserves the load-bearing payload via `--output-last-message`, and avoids betting on unproven drain fixes for what is also a codex CLI SIGPIPE bug.

## Test plan

- [x] `nix develop -c cargo test --features test-stub --locked` passes (33 codex-related tests including the updated three)
- [x] `nix develop -c cargo clippy --locked -- -D warnings` clean
- [x] `nix develop -c cargo fmt --check` clean
- [ ] CI green
- [ ] Codex bot review
- [ ] Reporter confirmation that the master-t9j0 reproducer is unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)