### PR TITLE
fmiw: cfg-gate test-stub-only imports (close gdda as false-positive)

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -5027,7 +5027,7 @@ mod tests {
     use std::collections::BTreeMap;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
-    use std::sync::Mutex;
+    #[cfg(feature = "test-stub")]
     use std::time::Duration;
 
     use crate::adapters::bv_process::NextBeadResponse;
@@ -5070,23 +5070,29 @@ mod tests {
         CommittedStageEntry, FullModeStage, RequirementsRun, RequirementsStatus,
     };
     use crate::contexts::requirements_drafting::service::RequirementsStorePort;
+    #[cfg(feature = "test-stub")]
     use crate::contexts::workflow_composition::retry_policy::{
         apply_test_retry_policy_overrides, RetryPolicy,
     };
-    use crate::shared::domain::{FailureClass, FlowPreset, ProjectId, StageCursor, StageId};
+    #[cfg(feature = "test-stub")]
+    use crate::shared::domain::FailureClass;
+    use crate::shared::domain::{FlowPreset, ProjectId, StageCursor, StageId};
     use crate::shared::error::AppError;
     use crate::test_support::br::{MockBrAdapter, MockBrResponse};
     use crate::test_support::bv::{MockBvAdapter, MockBvResponse};
     use crate::test_support::env::{lock_path_mutex, PathGuard};
     use tokio::sync::oneshot;
 
-    static RETRY_POLICY_ENV_MUTEX: Mutex<()> = Mutex::new(());
+    #[cfg(feature = "test-stub")]
+    static RETRY_POLICY_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    #[cfg(feature = "test-stub")]
     struct EnvVarGuard {
         key: &'static str,
         original: Option<std::ffi::OsString>,
     }
 
+    #[cfg(feature = "test-stub")]
     impl EnvVarGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let original = std::env::var_os(key);
@@ -5101,6 +5107,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "test-stub")]
     impl Drop for EnvVarGuard {
         fn drop(&mut self) {
             match &self.original {

--- a/src/contexts/workflow_composition/final_review.rs
+++ b/src/contexts/workflow_composition/final_review.rs
@@ -2969,13 +2969,16 @@ mod tests {
     use super::*;
     use crate::contexts::workflow_composition::panel_contracts::FinalReviewProposal;
 
+    #[cfg(feature = "test-stub")]
     static RETRY_POLICY_ENV_MUTEX: Mutex<()> = Mutex::new(());
 
+    #[cfg(feature = "test-stub")]
     struct EnvVarGuard {
         key: &'static str,
         original: Option<std::ffi::OsString>,
     }
 
+    #[cfg(feature = "test-stub")]
     impl EnvVarGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let original = std::env::var_os(key);
@@ -2990,6 +2993,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "test-stub")]
     impl Drop for EnvVarGuard {
         fn drop(&mut self) {
             match self.original.take() {


### PR DESCRIPTION
## Summary

Implementer-authored fix from the dogfood drain on bead \`fmiw\` (project state at \`.git/ralph-burning-live/projects/fmiw\`, commit \`1f63e8f4\`). The drain marked the run failed because of a transient flake in \`tests/cli.rs\` during the verification gate, but the actual code change is correct: 5/5 stress runs of \`cargo test --test cli\` pass locally, and the full \`cargo test\` suite (default and \`--features test-stub\`) is clean.

## Why

\`src/cli/run.rs::tests\` and \`src/contexts/workflow_composition/final_review.rs::tests\` use a few imports + helpers (\`Duration\`, \`RetryPolicy\`, \`apply_test_retry_policy_overrides\`, \`FailureClass\`, \`RETRY_POLICY_ENV_MUTEX\`, \`EnvVarGuard\`) that only matter when building with \`--features test-stub\`. Without the feature, they're unused — producing 6 warnings on \`cargo test\`. Cfg-gating them on the feature aligns the imports with the tests that actually need them.

## Impact

- Removes 6 unused-import / dead-code warnings on default \`cargo test\`.
- No production code change.
- \`fmiw\` (P1 bug) was the bead that originally tracked these warnings — surfaced by the first dogfood drain.
- \`gdda\` (P1 bug) is a false-positive follow-up filed by the second dogfood drain when its verification gate hit a transient flake. Will close it once this PR lands.

## Test plan

- [x] \`nix build\` green
- [x] \`cargo test\` (default features) — 1412+311+964+... all pass
- [x] \`cargo test --features test-stub\` — 1456+382+1185+... all pass  
- [x] \`cargo test --test cli\` stress: 5/5 clean
- [x] \`cargo clippy --locked -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)