### PR TITLE
f5o1: default flow Minimal → IterativeMinimal (close evi, 9ni.2.7, 9ni.9.3)

### DIFF
--- a/src/contexts/workspace_governance/config.rs
+++ b/src/contexts/workspace_governance/config.rs
@@ -20,8 +20,18 @@ use super::{load_workspace_config, workspace_config_path};
 
 /// Default: enabled.
 pub const DEFAULT_PROMPT_REVIEW_ENABLED: bool = true;
-/// Default: minimal.
-pub const DEFAULT_FLOW_PRESET: FlowPreset = FlowPreset::Minimal;
+/// Default: iterative_minimal.
+///
+/// Iterative minimal is preferred over plain `Minimal` because it keeps
+/// the plan_and_implement → final_review loop honest about convergence
+/// (`stable_rounds_required`, lowered to 1 by bead 2z8p) instead of
+/// single-shotting through. In the common 0-amendment case it costs the
+/// same as `Minimal` (one round, then immediate completion); when the
+/// reviewers find amendments it loops to convergence rather than
+/// shipping the first attempt — which matches how the drain harness
+/// has been configured all along (`FlowPreset::IterativeMinimal` in
+/// `test_support/drain_harness.rs`).
+pub const DEFAULT_FLOW_PRESET: FlowPreset = FlowPreset::IterativeMinimal;
 pub const DEFAULT_MAX_QA_ITERATIONS: u32 = 3;
 pub const DEFAULT_MAX_REVIEW_ITERATIONS: u32 = 3;
 pub const DEFAULT_PROMPT_REVIEW_MIN_REVIEWERS: usize = 2;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3424,7 +3424,7 @@ fn config_show_prints_effective_values_and_sources() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("[settings]"));
     assert!(stdout.contains("prompt_review.enabled = true # source: default"));
-    assert!(stdout.contains("default_flow = \"minimal\" # source: default"));
+    assert!(stdout.contains("default_flow = \"iterative_minimal\" # source: default"));
     assert!(stdout.contains("default_backend = \"claude\" # source: default"));
 }
 
@@ -4034,7 +4034,10 @@ fn config_get_prints_known_values_and_rejects_unknown_keys() {
         .output()
         .expect("run config get");
     assert!(known.status.success());
-    assert_eq!("minimal\n", String::from_utf8_lossy(&known.stdout));
+    assert_eq!(
+        "iterative_minimal\n",
+        String::from_utf8_lossy(&known.stdout)
+    );
 
     let unknown = Command::new(binary())
         .args(["config", "get", "unknown.key"])
@@ -4339,7 +4342,7 @@ fn project_create_succeeds_and_writes_all_canonical_files() {
 }
 
 #[test]
-fn project_create_defaults_to_minimal_flow_without_flag() {
+fn project_create_defaults_to_iterative_minimal_flow_without_flag() {
     let temp_dir = initialize_workspace_fixture();
     let prompt = write_prompt_fixture(temp_dir.path());
 
@@ -4348,9 +4351,9 @@ fn project_create_defaults_to_minimal_flow_without_flag() {
             "project",
             "create",
             "--id",
-            "minimal-default",
+            "iterative-minimal-default",
             "--name",
-            "Minimal Default",
+            "Iterative Minimal Default",
             "--prompt",
             prompt.to_str().unwrap(),
         ])
@@ -4365,13 +4368,14 @@ fn project_create_defaults_to_minimal_flow_without_flag() {
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Created project 'minimal-default'"));
-    assert!(stdout.contains("minimal"));
+    assert!(stdout.contains("Created project 'iterative-minimal-default'"));
+    assert!(stdout.contains("iterative_minimal"));
 
-    let project_toml =
-        fs::read_to_string(project_root(temp_dir.path(), "minimal-default").join("project.toml"))
-            .expect("read project.toml");
-    assert!(project_toml.contains("flow = \"minimal\""));
+    let project_toml = fs::read_to_string(
+        project_root(temp_dir.path(), "iterative-minimal-default").join("project.toml"),
+    )
+    .expect("read project.toml");
+    assert!(project_toml.contains("flow = \"iterative_minimal\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Change \`DEFAULT_FLOW_PRESET\` from \`FlowPreset::Minimal\` to \`FlowPreset::IterativeMinimal\`. Bead \`f5o1\`.

The drain harness has used \`IterativeMinimal\` all along (\`test_support/drain_harness.rs:918\`). Real drains went through \`effective_config.default_flow()\` which resolved to plain \`Minimal\` — a small but real divergence from what the harness has been validating.

Iterative-minimal is safe to default-on now that bead 2z8p lowered \`stable_rounds_required\` from 2 to 1. In the 0-amendment case it costs the same as plain \`Minimal\` (one round, immediate completion); when reviewers find amendments it loops to convergence rather than shipping the first attempt.

## Bead bookkeeping (closed alongside this PR)

- \`evi\` (P1, in_progress) — stated goal "Standard → Minimal" was already done; this PR ships the actual desired change.
- \`9ni.2.7\` (P1, in_progress) — milestone-store integration tests already exist (\`tests/unit/milestone_store_integration_test.rs\`, 1055 lines, last touched April 25).
- \`9ni.9.3\` (P2, in_progress) — task lineage in CLI output already exists (\`src/cli/task.rs\` lines 171-184, with help text mentioning milestone+bead lineage).

## Test plan

- [x] \`nix build\` green
- [x] \`cargo test\` — all 1419+311+1+964 tests pass (3 cli tests updated to expect \`iterative_minimal\`)
- [x] \`cargo clippy --locked -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Default project flow revised: New projects now initialize with the Iterative Minimal preset instead of Minimal, providing a more comprehensive workflow experience out of the box
  * Expanded documentation explaining iterative-minimal workflow behavior and capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->