### PR TITLE
6ol: remove dead docs-stage StageId variants (DocsPlan/DocsUpdate/DocsValidation)

### DIFF
--- a/src/adapters/stub_backend.rs
+++ b/src/adapters/stub_backend.rs
@@ -481,7 +481,7 @@ fn count_tokens(contents: &str) -> u32 {
 
 fn canned_payload_for_stage(stage_id: StageId) -> serde_json::Value {
     match stage_id {
-        StageId::PromptReview | StageId::Planning | StageId::DocsPlan | StageId::CiPlan => json!({
+        StageId::PromptReview | StageId::Planning | StageId::CiPlan => json!({
             "problem_framing": format!("Stub planning output for {}", stage_id.display_name()),
             "assumptions_or_open_questions": [
                 format!("Assumption captured for {}", stage_id.as_str())
@@ -501,7 +501,6 @@ fn canned_payload_for_stage(stage_id: StageId) -> serde_json::Value {
         StageId::Implementation
         | StageId::PlanAndImplement
         | StageId::ApplyFixes
-        | StageId::DocsUpdate
         | StageId::CiUpdate => json!({
             "change_summary": format!("Stub execution output for {}", stage_id.display_name()),
             "steps": [
@@ -519,7 +518,6 @@ fn canned_payload_for_stage(stage_id: StageId) -> serde_json::Value {
         | StageId::CompletionPanel
         | StageId::AcceptanceQa
         | StageId::FinalReview
-        | StageId::DocsValidation
         | StageId::CiValidation => json!({
             "outcome": "approved",
             "evidence": [format!("Stub validation output for {}", stage_id.display_name())],

--- a/src/contexts/agent_execution/policy.rs
+++ b/src/contexts/agent_execution/policy.rs
@@ -410,15 +410,12 @@ impl<'a> BackendPolicyService<'a> {
 /// Map a stage ID to its corresponding backend policy role (free function).
 pub fn stage_to_policy_role(stage_id: StageId) -> BackendPolicyRole {
     match stage_id {
-        StageId::PromptReview | StageId::Planning | StageId::DocsPlan | StageId::CiPlan => {
-            BackendPolicyRole::Planning
-        }
+        StageId::PromptReview | StageId::Planning | StageId::CiPlan => BackendPolicyRole::Planning,
         StageId::Implementation
         | StageId::PlanAndImplement
         | StageId::ApplyFixes
-        | StageId::DocsUpdate
         | StageId::CiUpdate => BackendPolicyRole::Implementer,
-        StageId::Qa | StageId::DocsValidation | StageId::CiValidation => BackendPolicyRole::Qa,
+        StageId::Qa | StageId::CiValidation => BackendPolicyRole::Qa,
         StageId::AcceptanceQa => BackendPolicyRole::AcceptanceQa,
         StageId::Review => BackendPolicyRole::Reviewer,
         StageId::CompletionPanel => BackendPolicyRole::Completer,

--- a/src/contexts/project_run_record/service.rs
+++ b/src/contexts/project_run_record/service.rs
@@ -2824,7 +2824,9 @@ fn planning_stage_for_flow(flow: FlowPreset) -> StageId {
     match flow {
         FlowPreset::Standard => StageId::Planning,
         FlowPreset::QuickDev => StageId::PlanAndImplement,
-        FlowPreset::DocsChange => StageId::DocsPlan,
+        // DocsChange is now an alias for Minimal (see bead gp7), so it
+        // routes to PlanAndImplement just like Minimal/IterativeMinimal.
+        FlowPreset::DocsChange => StageId::PlanAndImplement,
         FlowPreset::CiImprovement => StageId::CiPlan,
         FlowPreset::Minimal => StageId::PlanAndImplement,
         FlowPreset::IterativeMinimal => StageId::PlanAndImplement,

--- a/src/contexts/workflow_composition/contracts.rs
+++ b/src/contexts/workflow_composition/contracts.rs
@@ -64,18 +64,14 @@ pub struct ValidatedBundle {
 /// to exactly one contract.
 pub fn contract_for_stage(stage_id: StageId) -> StageContract {
     let family = match stage_id {
-        StageId::PromptReview | StageId::Planning | StageId::DocsPlan | StageId::CiPlan => {
-            ContractFamily::Planning
-        }
+        StageId::PromptReview | StageId::Planning | StageId::CiPlan => ContractFamily::Planning,
 
         StageId::Implementation
         | StageId::PlanAndImplement
         | StageId::ApplyFixes
-        | StageId::DocsUpdate
         | StageId::CiUpdate => ContractFamily::Execution,
 
         StageId::Qa
-        | StageId::DocsValidation
         | StageId::CiValidation
         | StageId::AcceptanceQa
         | StageId::Review

--- a/src/contexts/workflow_composition/engine.rs
+++ b/src/contexts/workflow_composition/engine.rs
@@ -4172,7 +4172,7 @@ where
 
         // ── Local validation dispatch for docs/CI stages ────────────────────
 
-        if stage_id == StageId::DocsValidation || stage_id == StageId::CiValidation {
+        if stage_id == StageId::CiValidation {
             // Emit stage_entered event for local validation.
             *seq += 1;
             let stage_entered = journal::stage_entered_event(
@@ -4226,9 +4226,6 @@ where
             );
 
             let commands = match stage_id {
-                StageId::DocsValidation => {
-                    effective_config.validation_policy().docs_commands.clone()
-                }
                 StageId::CiValidation => effective_config.validation_policy().ci_commands.clone(),
                 _ => vec![],
             };
@@ -8843,15 +8840,6 @@ fn stage_objective(stage_id: StageId) -> &'static str {
         }
         StageId::ApplyFixes => {
             "apply the requested fixes, summarize the edits, and record the validation performed"
-        }
-        StageId::DocsPlan => {
-            "plan the documentation updates required to support the requested change"
-        }
-        StageId::DocsUpdate => {
-            "update the documentation accurately and summarize what changed"
-        }
-        StageId::DocsValidation => {
-            "validate documentation accuracy, clarity, and completeness"
         }
         StageId::CiPlan => {
             "plan the CI workflow updates needed for the requested change"

--- a/src/contexts/workflow_composition/validation.rs
+++ b/src/contexts/workflow_composition/validation.rs
@@ -44,7 +44,6 @@ pub async fn run_local_validation(
     repo_root: &Path,
 ) -> (ValidationPayload, ValidationGroupResult) {
     let group_name = match stage_id {
-        StageId::DocsValidation => "docs_validation",
         StageId::CiValidation => "ci_validation",
         _ => "local_validation",
     };

--- a/src/shared/domain.rs
+++ b/src/shared/domain.rs
@@ -269,18 +269,12 @@ impl BackendRole {
 
     pub fn for_stage(stage_id: StageId) -> Self {
         match stage_id {
-            StageId::PromptReview | StageId::Planning | StageId::DocsPlan | StageId::CiPlan => {
-                Self::Planner
-            }
+            StageId::PromptReview | StageId::Planning | StageId::CiPlan => Self::Planner,
             StageId::Implementation
             | StageId::PlanAndImplement
             | StageId::ApplyFixes
-            | StageId::DocsUpdate
             | StageId::CiUpdate => Self::Implementer,
-            StageId::Qa
-            | StageId::DocsValidation
-            | StageId::CiValidation
-            | StageId::AcceptanceQa => Self::QaValidator,
+            StageId::Qa | StageId::CiValidation | StageId::AcceptanceQa => Self::QaValidator,
             StageId::CompletionPanel | StageId::FinalReview => Self::CompletionJudge,
             StageId::Review => Self::Reviewer,
         }
@@ -706,16 +700,13 @@ pub enum StageId {
     FinalReview,
     PlanAndImplement,
     ApplyFixes,
-    DocsPlan,
-    DocsUpdate,
-    DocsValidation,
     CiPlan,
     CiUpdate,
     CiValidation,
 }
 
 impl StageId {
-    pub const ALL: [Self; 16] = [
+    pub const ALL: [Self; 13] = [
         Self::PromptReview,
         Self::Planning,
         Self::Implementation,
@@ -726,9 +717,6 @@ impl StageId {
         Self::FinalReview,
         Self::PlanAndImplement,
         Self::ApplyFixes,
-        Self::DocsPlan,
-        Self::DocsUpdate,
-        Self::DocsValidation,
         Self::CiPlan,
         Self::CiUpdate,
         Self::CiValidation,
@@ -746,9 +734,6 @@ impl StageId {
             Self::FinalReview => "Final Review",
             Self::PlanAndImplement => "Plan and Implement",
             Self::ApplyFixes => "Apply Fixes",
-            Self::DocsPlan => "Docs Plan",
-            Self::DocsUpdate => "Docs Update",
-            Self::DocsValidation => "Docs Validation",
             Self::CiPlan => "CI Plan",
             Self::CiUpdate => "CI Update",
             Self::CiValidation => "CI Validation",
@@ -767,9 +752,6 @@ impl StageId {
             Self::FinalReview => "final_review",
             Self::PlanAndImplement => "plan_and_implement",
             Self::ApplyFixes => "apply_fixes",
-            Self::DocsPlan => "docs_plan",
-            Self::DocsUpdate => "docs_update",
-            Self::DocsValidation => "docs_validation",
             Self::CiPlan => "ci_plan",
             Self::CiUpdate => "ci_update",
             Self::CiValidation => "ci_validation",
@@ -777,9 +759,9 @@ impl StageId {
     }
 
     /// Returns `true` for stages that run local validation commands and do not
-    /// require a backend agent (docs_validation, ci_validation).
+    /// require a backend agent (currently only `ci_validation`).
     pub fn is_local_validation(self) -> bool {
-        matches!(self, Self::DocsValidation | Self::CiValidation)
+        matches!(self, Self::CiValidation)
     }
 }
 
@@ -804,9 +786,6 @@ impl FromStr for StageId {
             "final_review" => Ok(Self::FinalReview),
             "plan_and_implement" => Ok(Self::PlanAndImplement),
             "apply_fixes" => Ok(Self::ApplyFixes),
-            "docs_plan" => Ok(Self::DocsPlan),
-            "docs_update" => Ok(Self::DocsUpdate),
-            "docs_validation" => Ok(Self::DocsValidation),
             "ci_plan" => Ok(Self::CiPlan),
             "ci_update" => Ok(Self::CiUpdate),
             "ci_validation" => Ok(Self::CiValidation),

--- a/src/shared/domain.rs
+++ b/src/shared/domain.rs
@@ -267,6 +267,15 @@ impl BackendRole {
         matches!(self, Self::Implementer | Self::Reviewer | Self::QaValidator)
     }
 
+    /// Map a [`StageId`] to the [`BackendRole`] that drives its agent
+    /// invocation. Stages that run locally (no agent) — currently only
+    /// `CiValidation`, see [`StageId::is_local_validation`] — return
+    /// [`Self::QaValidator`] as a defensive default. The engine's local-
+    /// validation dispatch (`engine.rs`) routes those stages to
+    /// `validation::run_local_validation` BEFORE consulting this role
+    /// mapping, so the returned role is unused in practice. Callers that
+    /// need to skip backend resolution for local stages MUST first check
+    /// `stage_id.is_local_validation()`.
     pub fn for_stage(stage_id: StageId) -> Self {
         match stage_id {
             StageId::PromptReview | StageId::Planning | StageId::CiPlan => Self::Planner,

--- a/tests/unit/backend_diagnostics_test.rs
+++ b/tests/unit/backend_diagnostics_test.rs
@@ -1547,9 +1547,10 @@ fn check_passes_when_all_roles_overridden_and_default_backend_disabled() {
     let config = EffectiveConfig::load(temp_dir.path()).expect("load config");
     let service = BackendDiagnosticsService::new(&config);
 
-    // docs_change flow: DocsPlan→Planner, DocsUpdate→Implementer,
-    // DocsValidation→Qa, Review→Reviewer — all have overrides, so
-    // disabled default_backend should NOT cause failure.
+    // docs_change flow is now an alias for Minimal (gp7), so it goes
+    // through PlanAndImplement→Implementer + FinalReview→CompletionJudge.
+    // All roles have overrides, so disabled default_backend should NOT
+    // cause failure.
     let result = service.check_backends(FlowPreset::DocsChange);
     assert!(
         result.passed,

--- a/tests/unit/stage_contract_test.rs
+++ b/tests/unit/stage_contract_test.rs
@@ -125,12 +125,7 @@ fn every_stage_in_every_built_in_flow_has_contract_coverage() {
 
 #[test]
 fn planning_stages_map_to_planning_family() {
-    for stage_id in [
-        StageId::PromptReview,
-        StageId::Planning,
-        StageId::DocsPlan,
-        StageId::CiPlan,
-    ] {
+    for stage_id in [StageId::PromptReview, StageId::Planning, StageId::CiPlan] {
         assert_eq!(
             contract_for_stage(stage_id).family,
             ContractFamily::Planning,
@@ -145,7 +140,6 @@ fn execution_stages_map_to_execution_family() {
         StageId::Implementation,
         StageId::PlanAndImplement,
         StageId::ApplyFixes,
-        StageId::DocsUpdate,
         StageId::CiUpdate,
     ] {
         assert_eq!(
@@ -160,7 +154,6 @@ fn execution_stages_map_to_execution_family() {
 fn validation_stages_map_to_validation_family() {
     for stage_id in [
         StageId::Qa,
-        StageId::DocsValidation,
         StageId::CiValidation,
         StageId::AcceptanceQa,
         StageId::Review,

--- a/tests/unit/validation_runner_test.rs
+++ b/tests/unit/validation_runner_test.rs
@@ -218,7 +218,7 @@ fn failing_excerpts_from_stderr() {
 #[test]
 fn render_validation_group_output() {
     let result = ValidationGroupResult {
-        group_name: "docs_validation".to_owned(),
+        group_name: "ci_validation".to_owned(),
         commands: vec![ValidationCommandResult {
             command: "echo ok".to_owned(),
             exit_code: Some(0),
@@ -231,7 +231,7 @@ fn render_validation_group_output() {
     };
     let rendered = render_validation_group(&result);
     assert!(rendered.contains("PASSED"));
-    assert!(rendered.contains("docs_validation"));
+    assert!(rendered.contains("ci_validation"));
     assert!(rendered.contains("echo ok"));
 }
 
@@ -385,7 +385,7 @@ fn failing_excerpts_handles_non_ascii_output() {
 fn local_validation_empty_commands_passes() {
     let rt = rt();
     let (payload, group) = rt.block_on(validation::run_local_validation(
-        ralph_burning::shared::domain::StageId::DocsValidation,
+        ralph_burning::shared::domain::StageId::CiValidation,
         &[],
         Path::new("/tmp"),
     ));
@@ -417,7 +417,7 @@ fn local_validation_failing_command_requests_changes() {
 fn local_validation_passing_command_approves() {
     let rt = rt();
     let (payload, group) = rt.block_on(validation::run_local_validation(
-        ralph_burning::shared::domain::StageId::DocsValidation,
+        ralph_burning::shared::domain::StageId::CiValidation,
         &["true".to_owned()],
         Path::new("/tmp"),
     ));


### PR DESCRIPTION
## Summary

Drop \`StageId::DocsPlan\`, \`StageId::DocsUpdate\`, and \`StageId::DocsValidation\`. They've been dead code since bead \`gp7\` made \`FlowPreset::DocsChange\` an alias for \`Minimal\` (PlanAndImplement + FinalReview) — nothing instantiates them and no flow routes to them. Bead \`6ol\`.

Per the bead author: "remove them. clean everything. we don't need hypothetical migrations/compatibility".

## Changes

- \`StageId::ALL\` shrinks from 16 → 13 entries.
- \`FlowPreset::DocsChange => StageId::PlanAndImplement\` (matches its Minimal alias).
- \`is_local_validation\` now matches only \`CiValidation\`.
- 10 files touched: domain.rs (the source of truth), policy.rs, service.rs, engine.rs, validation.rs, contracts.rs, stub_backend.rs, plus 3 test files.

## What's kept

- \`StageId::CiPlan/CiUpdate/CiValidation\` — still in use by ci_improvement flow.
- \`FlowPreset::DocsChange\` — keep as a flow alias name.

## Test plan

- [x] \`nix build\` green
- [x] \`cargo test\` passes 1419+311+1+964 tests
- [x] \`cargo clippy --locked -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] No remaining references to DocsPlan/DocsUpdate/DocsValidation in src/ or tests/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed documentation-specific workflow stages; docs flows now route through CI-based planning and validation stages.
  * Local validation dispatch narrowed to trigger only for CI validation.
* **Tests**
  * Updated unit tests and test descriptions to match the new CI-based stage mappings and validation group names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->