### PR TITLE
docs: mention rb-lite as a lighter alternative in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ ralph-burning is a multi-stage code-execution orchestrator. It turns a problem p
 
 Ad hoc LLM CLI sessions are easy to start and hard to operate: state is scattered, review loops are manual, and crash recovery depends on terminal history. ralph-burning adds durable project/run records, rollback points, multi-reviewer panels with arbiter behavior, and `.beads` integration as the canonical work graph. The most-used flow is `iterative_minimal`, which cycles `plan_and_implement` until the implementation is stable, then runs `final_review`.
 
+> **Considering a lighter alternative?** For single-branch, single-task work where you don't need durable cross-session state, multi-stage flows, beads integration, or rollback points, [`rb-lite`](https://github.com/douglaz/rb-lite) is a ~700-line Bash CLI that runs the same kind of implement→review loop with codex + claude as a parallel reviewer panel. It's simpler to read end-to-end, faster to converge for small tasks, and stays out of your way (no project/run database). Reach for `ralph-burning` when the work is bigger than one branch and benefits from persistent orchestration; reach for `rb-lite` when it isn't.
+
 ## Quick start
 
 Run the released CLI directly with Nix, or build the local checkout:


### PR DESCRIPTION
## Summary
- Add a one-paragraph callout under "Why it exists" pointing readers at [`rb-lite`](https://github.com/douglaz/rb-lite) for single-branch, single-task work.
- Honest framing: rb-lite is simpler (~700 lines of bash) and faster to converge for small tasks; ralph-burning is the right pick when work is bigger than one branch and benefits from persistent orchestration (durable runs, multi-stage flows, beads, rollback).
- Pure docs change. No code touched.

## Test plan
- [ ] No code changes; CI should be green.
- [ ] Render the README locally / on GitHub to confirm the new blockquote sits cleanly between "Why it exists" and "Quick start".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to introduce rb-lite as a lighter alternative for single-branch, single-task workflows, with guidance on when to use it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->